### PR TITLE
Improve optimization in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,6 @@ version = "1.1.0"
 features = ["rustc_1_40", "alloc"]
 
 [profile.release]
-opt-level = 3
 lto = 'thin'
-codegen-units = 1
-incremental = true
 debug = true
 panic = 'abort'


### PR DESCRIPTION
1. `lto = "thin"` + `codegen-units` is not a good idea, see https://github.com/rust-lang/rust/issues/47745. `lto = true` and `codegen-units = 1` could potentially be better, though, although I doubt it'd matter too much, as the performance difference would likely only show in benchmarks, with little impact on actual use, so it's just more convenient to have the better linking speed with thin LTO.
2. `opt-level = 3` is already the default.
3. incremental has occasional strange bugs, best to leave it off (https://github.com/rust-lang/rust/issues/81280, https://github.com/rust-lang/rust/issues/84970)