### PR TITLE
Call non-hooked proc on linux

### DIFF
--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -677,7 +677,11 @@ fn post_process() {
 							let _ = sender.try_send(Box::new(move || {
 								for &i in &copy {
 									let turf = unsafe { Value::turf_by_id_unchecked(i) };
-									turf.get(byond_string!("air"))?.call("react", &[&turf])?;
+									if cfg!(target_os="linux") {
+										turf.get(byond_string!("air"))?.call("react_unhooked", &[&turf])?;
+									} else {
+										turf.get(byond_string!("air"))?.call("react", &[&turf])?;
+									}
 								}
 								Ok(Value::null())
 							}));
@@ -688,7 +692,11 @@ fn post_process() {
 		let _ = sender.try_send(Box::new(move || {
 			for &i in &reacters {
 				let turf = unsafe { Value::turf_by_id_unchecked(i) };
-				turf.get(byond_string!("air"))?.call("react", &[&turf])?;
+				if cfg!(target_os="linux") {
+					turf.get(byond_string!("air"))?.call("react_unhooked", &[&turf])?;
+				} else {
+					turf.get(byond_string!("air"))?.call("react", &[&turf])?;
+				}
 			}
 			for &i in &visual_updaters {
 				let turf = unsafe { Value::turf_by_id_unchecked(i) };

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -678,7 +678,7 @@ fn post_process() {
 								for &i in &copy {
 									let turf = unsafe { Value::turf_by_id_unchecked(i) };
 									if cfg!(target_os="linux") {
-										turf.get(byond_string!("air"))?.call("react_unhooked", &[&turf])?;
+										turf.get(byond_string!("air"))?.call("vv_react", &[&turf])?;
 									} else {
 										turf.get(byond_string!("air"))?.call("react", &[&turf])?;
 									}
@@ -693,7 +693,7 @@ fn post_process() {
 			for &i in &reacters {
 				let turf = unsafe { Value::turf_by_id_unchecked(i) };
 				if cfg!(target_os="linux") {
-					turf.get(byond_string!("air"))?.call("react_unhooked", &[&turf])?;
+					turf.get(byond_string!("air"))?.call("vv_react", &[&turf])?;
 				} else {
 					turf.get(byond_string!("air"))?.call("react", &[&turf])?;
 				}


### PR DESCRIPTION
For now, auxtools doesn't support calling hooked procs through byond from auxmos, so the workaround is to use the vv_react proc which simply calls the original react proc, and let auxmos call that instead.