### PR TITLE
Makes tritfires actually change reaction_results["fire"]

### DIFF
--- a/src/reaction/hooks.rs
+++ b/src/reaction/hooks.rs
@@ -125,6 +125,17 @@ fn tritfire(byond_air: &Value, holder: &Value) {
 		air.adjust_moles(water, burned_fuel / TRITIUM_BURN_OXY_FACTOR);
 		let energy_released = FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel;
 		let new_temp = (initial_energy + energy_released) / air.heat_capacity();
+		let cached_results = byond_air
+			.get_list(byond_string!("reaction_results"))
+			.map_err(|_| {
+				runtime!(
+					"Attempt to interpret non-list value as list {} {}:{}",
+					std::file!(),
+					std::line!(),
+					std::column!()
+				)
+			})?;
+		cached_results.set(byond_string!("fire"), Value::from(burned_fuel))?;
 		air.set_temperature(new_temp);
 		air.garbage_collect();
 		Ok((burned_fuel, energy_released, new_temp))


### PR DESCRIPTION
Not sure if this is in the right place, but I put it in the place that vaguely corresponds to where it was in the BYOND version of it, and it works when tested.