### PR TITLE
make decomp use indexsets instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "float-ord",
  "flume",
  "fxhash",
+ "indexmap",
  "itertools",
  "nonmax",
  "parking_lot",
@@ -355,6 +356,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +375,16 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "instant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ flume = "0.10.5"
 parking_lot = "0.11.1"
 fxhash = "0.2.1"
 nonmax = "0.5.0"
+indexmap = "1.7.0"
 
 [dependencies.dashmap]
 version = "4.0.2"

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -44,7 +44,7 @@ const fn adj_flag_to_idx(adj_flag: u8) -> usize {
 type TurfID = u32;
 
 // TurfMixture can be treated as "immutable" for all intents and purposes--put other data somewhere else
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Hash, Eq, PartialEq)]
 struct TurfMixture {
 	pub mix: usize,
 	pub adjacency: u8,


### PR DESCRIPTION
insertion orders are kept, and is O(1) with no duplicates