### PR TITLE
changes fastmos hash method, tries to fix planet turfs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +65,7 @@ dependencies = [
 name = "auxmos"
 version = "0.2.0"
 dependencies = [
+ "ahash 0.7.4",
  "auxcallback",
  "auxcleanup",
  "auxtools",
@@ -245,7 +257,7 @@ version = "3.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
 dependencies = [
- "ahash",
+ "ahash 0.3.8",
  "cfg-if 0.1.10",
  "num_cpus",
 ]
@@ -733,6 +745,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ parking_lot = "0.11.1"
 fxhash = "0.2.1"
 nonmax = "0.5.0"
 indexmap = "1.7.0"
+ahash = "0.7.4"
 
 [dependencies.dashmap]
 version = "4.0.2"

--- a/src/gas/mixture.rs
+++ b/src/gas/mixture.rs
@@ -492,7 +492,7 @@ impl Mixture {
 	/// A hashed representation of the visibility of a gas, so that it only needs to update vis when actually changed.
 	pub fn vis_hash_changed(&self, gas_visibility: &[Option<f32>]) -> bool {
 		use std::hash::Hasher;
-		let mut hasher: fxhash::FxHasher64 = fxhash::FxHasher64::default();
+		let mut hasher: ahash::AHasher = ahash::AHasher::default();
 		for (i, gas) in self.enumerate() {
 			if let Some(amt) = unsafe { gas_visibility.get_unchecked(i) }.filter(|&amt| gas >= amt)
 			{


### PR DESCRIPTION
monstermos now uses Fxhash for the hashmap and indexsets.
vis hash is now Ahash for better perf. MixwithID is also Ahash.
excluded planet turfs from giver and takers processing
switched back some stupid uses of indexset
fastmos made even faster