### PR TITLE
more monstermos related fixes

### DIFF
--- a/src/turfs/monstermos.rs
+++ b/src/turfs/monstermos.rs
@@ -760,8 +760,8 @@ pub(crate) fn equalize(
 	let mut queue_cycle_slow = 1;
 	let mut found_turfs: HashSet<TurfID, FxBuildHasher>
 		= HashSet::with_hasher(FxBuildHasher::default());
-	let mut turf_cache: HashMap<TurfID, TurfMixture, FxBuildHasher> = HashMap::with_hasher(FxBuildHasher::default());
 	for &i in high_pressure_turfs.iter() {
+		let mut turf_cache: HashMap<TurfID, TurfMixture, FxBuildHasher> = HashMap::with_hasher(FxBuildHasher::default());
 		if found_turfs.contains(&i)
 			|| turf_gases().get(&i).map_or(true, |m| {
 				!m.enabled()


### PR DESCRIPTION
- made flood fill cache turf adj infos, preventing map changes mid processing from screwing up everything.
- decompression no longer copies infos as it's not needed.
- adjacency checking no longer ignores sleeping turfs.
- planet atmos processing is no longer deferred.