### PR TITLE
Generic fires rework; for stupid reasons, also incorporates fusion rework

### DIFF
--- a/src/gas/types.rs
+++ b/src/gas/types.rs
@@ -121,9 +121,9 @@ pub struct GasType {
 	/// The moles at which the gas's overlay or other appearance shows up. If None, gas is never visible.
 	/// Byond: `moles_visible`, a number.
 	pub moles_visible: Option<f32>,
-	/// Amount of energy released per mole of material burned in generic fires.
+	/// Standard enthalpy of formation.
 	/// Byond: `fire_energy_released`, a number.
-	pub fire_energy_released: f32,
+	pub enthalpy: f32,
 	/// Amount of radiation released per mole burned.
 	/// Byond: `fire_radiation_released`, a number.
 	pub fire_radiation_released: f32,
@@ -201,8 +201,8 @@ impl GasType {
 						None
 					}
 				}),
-			fire_energy_released: gas
-				.get_number(byond_string!("fire_energy_released"))
+			enthalpy: gas
+				.get_number(byond_string!("enthalpy"))
 				.unwrap_or_default(),
 			fire_radiation_released: gas
 				.get_number(byond_string!("fire_radiation_released"))

--- a/src/gas/types.rs
+++ b/src/gas/types.rs
@@ -88,6 +88,12 @@ impl GasRef {
 	}
 }
 
+#[derive(Clone)]
+pub enum FireProductInfo {
+	Generic(Vec<(GasRef, f32)>),
+	Plasma, // yeah, just hardcoding the funny trit production
+}
+
 /// An individual gas type. Contains a whole lot of info attained from Byond when the gas is first registered.
 /// If you don't have any of these, just fork auxmos and remove them, many of these are not necessary--for example,
 /// if you don't have fusion, you can just remove fusion_power.
@@ -118,12 +124,15 @@ pub struct GasType {
 	/// Amount of energy released per mole of material burned in generic fires.
 	/// Byond: `fire_energy_released`, a number.
 	pub fire_energy_released: f32,
+	/// Amount of radiation released per mole burned.
+	/// Byond: `fire_radiation_released`, a number.
+	pub fire_radiation_released: f32,
 	/// Either fuel info, oxidation info or neither. See the documentation on the respective types.
 	/// Byond: `oxidation_temperature` and `oxidation_rate` XOR `fire_temperature` and `fire_burn_rate`
 	pub fire_info: FireInfo,
 	/// A vector of gas-amount pairs. GasRef is just which gas, the f32 is moles made/mole burned.
 	/// Byond: `fire_products`, a list of gas IDs associated with amounts.
-	pub fire_products: Option<Vec<(GasRef, f32)>>,
+	pub fire_products: Option<FireProductInfo>,
 }
 
 impl GasType {
@@ -133,14 +142,7 @@ impl GasType {
 			idx,
 			id: gas.get_string(byond_string!("id"))?.into_boxed_str(),
 			name: gas.get_string(byond_string!("name"))?.into_boxed_str(),
-			flags: gas.get_number(byond_string!("flags")).map_err(|_| {
-				runtime!(
-					"Attempt to interpret non-number value as number {} {}:{}",
-					std::file!(),
-					std::line!(),
-					std::column!()
-				)
-			})? as u32,
+			flags: gas.get_number(byond_string!("flags")).unwrap_or_default() as u32,
 			specific_heat: gas
 				.get_number(byond_string!("specific_heat"))
 				.map_err(|_| {
@@ -151,14 +153,9 @@ impl GasType {
 						std::column!()
 					)
 				})?,
-			fusion_power: gas.get_number(byond_string!("fusion_power")).map_err(|_| {
-				runtime!(
-					"Attempt to interpret non-number value as number {} {}:{}",
-					std::file!(),
-					std::line!(),
-					std::column!()
-				)
-			})?,
+			fusion_power: gas
+				.get_number(byond_string!("fusion_power"))
+				.unwrap_or_default(),
 			moles_visible: gas.get_number(byond_string!("moles_visible")).ok(),
 			fire_info: {
 				if let Ok(temperature) = gas.get_number(byond_string!("oxidation_temperature")) {
@@ -175,26 +172,41 @@ impl GasType {
 					FireInfo::None
 				}
 			},
-			fire_products: if let Ok(products) = gas.get_list(byond_string!("fire_products")) {
-				Some(
-					(1..=products.len())
-						.filter_map(|i| {
-							let s = products.get(i).unwrap();
-							s.as_string()
-								.and_then(|s_str| {
-									products
-										.get(s)
-										.and_then(|v| v.as_number())
-										.map(|amount| (GasRef::Deferred(s_str), amount))
+			fire_products: gas
+				.get(byond_string!("fire_products"))
+				.ok()
+				.and_then(|product_info| {
+					if let Ok(products) = product_info.as_list() {
+						Some(FireProductInfo::Generic(
+							(1..=products.len())
+								.filter_map(|i| {
+									let s = products.get(i).unwrap();
+									s.as_string()
+										.and_then(|s_str| {
+											products
+												.get(s)
+												.and_then(|v| v.as_number())
+												.map(|amount| (GasRef::Deferred(s_str), amount))
+										})
+										.ok()
 								})
-								.ok()
-						})
-						.collect(),
-				)
-			} else {
-				None
-			},
-			fire_energy_released: gas.get_number(byond_string!("fire_energy_released"))?,
+								.collect(),
+						))
+					} else if product_info
+						.as_string()
+						.map_or(false, |s| s == "plasma_fire")
+					{
+						Some(FireProductInfo::Plasma)
+					} else {
+						None
+					}
+				}),
+			fire_energy_released: gas
+				.get_number(byond_string!("fire_energy_released"))
+				.unwrap_or_default(),
+			fire_radiation_released: gas
+				.get_number(byond_string!("fire_radiation_released"))
+				.unwrap_or_default(),
 		})
 	}
 }
@@ -352,9 +364,11 @@ pub fn update_gas_refs() {
 		.unwrap_or_else(|| panic!("Gases not loaded yet! Uh oh!"))
 		.iter_mut()
 		.for_each(|gas| {
-			if let Some(products) = gas.fire_products.as_mut() {
-				for product in products.iter_mut() {
-					product.0.update().unwrap();
+			if let Some(product_info) = gas.fire_products.as_mut() {
+				if let FireProductInfo::Generic(products) = product_info {
+					for product in products.iter_mut() {
+						product.0.update().unwrap();
+					}
 				}
 			}
 		});

--- a/src/reaction/hooks.rs
+++ b/src/reaction/hooks.rs
@@ -2,8 +2,7 @@ use auxtools::*;
 
 use crate::gas::{
 	constants::*, gas_fusion_power, gas_idx_from_string, with_gas_info, with_mix, with_mix_mut,
-	GasIDX,
-	FireProductInfo
+	FireProductInfo, GasIDX,
 };
 
 const SUPER_SATURATION_THRESHOLD: f32 = 96.0;

--- a/src/reaction/hooks.rs
+++ b/src/reaction/hooks.rs
@@ -174,109 +174,147 @@ fn tritfire(byond_air: &Value, holder: &Value) {
 #[cfg(feature = "fusion_hook")]
 #[hook("/datum/gas_reaction/fusion/react")]
 fn fusion(byond_air: Value, holder: Value) {
-	use std::f32::consts::PI;
-	const TOROID_VOLUME_BREAKEVEN: f32 = 1000.0;
-	const INSTABILITY_GAS_FACTOR: f32 = 0.003;
+	const TOROID_CALCULATED_THRESHOLD: f32 = 5.96;			// changing it by 0.1 generally doubles or halves fusion temps
+	const INSTABILITY_GAS_POWER_FACTOR: f32 = 3.0;
 	const PLASMA_BINDING_ENERGY: f32 = 20_000_000.0;
 	const FUSION_TRITIUM_MOLES_USED: f32 = 1.0;
 	const FUSION_INSTABILITY_ENDOTHERMALITY: f32 = 2.0;
-	const FUSION_TRITIUM_CONVERSION_COEFFICIENT: f32 = 1E-10;
+	const FUSION_TRITIUM_CONVERSION_COEFFICIENT: f32 = 0.002;
 	const FUSION_MOLE_THRESHOLD: f32 = 250.0;
+	const FUSION_SCALE_DIVISOR:f32 = 10.0;					// Used to be Pi
+	const FUSION_MINIMAL_SCALE:f32 = 50.0;
+	const FUSION_SLOPE_DIVISOR:f32 = 1250.0;				// This number is probably the safest number to change
+	const FUSION_ENERGY_TRANSLATION_EXPONENT:f32 = 1.25;	// This number is probably the most dangerous number to change
+	const FUSION_BASE_TEMPSCALE:f32	= 6.0;       			// This number is responsible for orchestrating fusion temperatures
+	const FUSION_MIDDLE_ENERGY_REFERENCE:f32 = 1E+6;		// This number is deceptively dangerous; sort of tied to TOROID_CALCULATED_THRESHOLD
+	const FUSION_BUFFER_DIVISOR:f32 = 1.0;					// Increase this to cull unrobust fusions faster
 	let plas = gas_idx_from_string(GAS_PLASMA)?;
 	let co2 = gas_idx_from_string(GAS_CO2)?;
-	let (initial_energy, initial_plasma, initial_carbon, scale_factor, toroidal_size, gas_power) =
+	let trit = gas_idx_from_string(GAS_TRITIUM)?;
+	let h2o = gas_idx_from_string(GAS_H2O)?;
+	let bz = gas_idx_from_string(GAS_BZ)?;
+	let o2 = gas_idx_from_string(GAS_O2)?;
+	let (initial_energy, initial_plasma, initial_carbon, scale_factor, temperature_scale, gas_power) =
 		with_mix(byond_air, |air| {
 			Ok((
 				air.thermal_energy(),
 				air.get_moles(plas),
 				air.get_moles(co2),
-				air.volume / PI,
-				(2.0 * PI)
-					+ ((air.volume - TOROID_VOLUME_BREAKEVEN) / TOROID_VOLUME_BREAKEVEN).atan(),
+				(air.volume / FUSION_SCALE_DIVISOR).max(FUSION_MINIMAL_SCALE),
+				air.get_temperature().log10(),
 				air.enumerate()
 					.fold(0.0, |acc, (i, amt)| acc + gas_fusion_power(&i) * amt),
 			))
 		})?;
-	let instability = (gas_power * INSTABILITY_GAS_FACTOR)
-		.powi(2)
+	//The size of the phase space hypertorus
+	let toroidal_size = TOROID_CALCULATED_THRESHOLD
+	+ { if temperature_scale <= FUSION_BASE_TEMPSCALE {
+		(temperature_scale - FUSION_BASE_TEMPSCALE) / FUSION_BUFFER_DIVISOR
+	} else {
+		(4.0_f32.powf(temperature_scale - FUSION_BASE_TEMPSCALE)) / FUSION_SLOPE_DIVISOR
+	}
+	};
+	let instability = (gas_power * INSTABILITY_GAS_POWER_FACTOR)
 		.rem_euclid(toroidal_size);
 	byond_air.call("set_analyzer_results", &[&Value::from(instability)])?;
+	let mut thermal_energy = initial_energy;
+
+	//We have to scale the amounts of carbon and plasma down a significant amount in order to show the chaotic dynamics we want
 	let mut plasma = (initial_plasma - FUSION_MOLE_THRESHOLD) / scale_factor;
+	//We also subtract out the threshold amount to make it harder for fusion to burn itself out.
 	let mut carbon = (initial_carbon - FUSION_MOLE_THRESHOLD) / scale_factor;
-	plasma = (plasma - instability * carbon.sin()).rem_euclid(toroidal_size);
+
 	//count the rings. ss13's modulus is positive, this ain't, who knew
+	plasma = (plasma - instability * carbon.sin()).rem_euclid(toroidal_size);
 	carbon = (carbon - plasma).rem_euclid(toroidal_size);
+
+	//Scales the gases back up
 	plasma = plasma * scale_factor + FUSION_MOLE_THRESHOLD;
 	carbon = carbon * scale_factor + FUSION_MOLE_THRESHOLD;
+
+	let delta_plasma = (initial_plasma - plasma).min(toroidal_size * scale_factor * 1.5);
+
+	//Energy is gained or lost corresponding to the creation or destruction of mass.
+	//Low instability prevents endothermality while higher instability acutally encourages it.
+	//Reaction energy can be negative or positive, for both exothermic and endothermic reactions.
 	let reaction_energy = {
-		let delta_plasma = initial_plasma - plasma;
-		if delta_plasma < 0.0 {
-			if instability < FUSION_INSTABILITY_ENDOTHERMALITY {
-				0.0
-			} else {
-				delta_plasma
-					* PLASMA_BINDING_ENERGY
-					* (instability - FUSION_INSTABILITY_ENDOTHERMALITY).sqrt()
-			}
+		if (delta_plasma > 0.0) || (instability <= FUSION_INSTABILITY_ENDOTHERMALITY) {
+			(delta_plasma * PLASMA_BINDING_ENERGY)
+			.max(0.0)
 		} else {
 			delta_plasma * PLASMA_BINDING_ENERGY
+				* ((instability-FUSION_INSTABILITY_ENDOTHERMALITY).sqrt())
 		}
 	};
-	if initial_energy + reaction_energy < 0.0 {
-		Ok(Value::from(0.0))
-	} else {
-		let tritium = gas_idx_from_string(GAS_TRITIUM)?;
-		let (byproduct_a, byproduct_b, tritium_conversion_coefficient) = {
-			if reaction_energy > 0.0 {
-				(
-					gas_idx_from_string(GAS_O2)?,
-					gas_idx_from_string(GAS_NITROUS)?,
-					FUSION_TRITIUM_CONVERSION_COEFFICIENT,
-				)
-			} else {
-				(
-					gas_idx_from_string(GAS_BZ)?,
-					gas_idx_from_string(GAS_NITRYL)?,
-					-FUSION_TRITIUM_CONVERSION_COEFFICIENT,
-				)
-			}
-		};
-		with_mix_mut(byond_air, |air| {
-			air.adjust_moles(tritium, -FUSION_TRITIUM_MOLES_USED);
-			air.set_moles(plas, plasma);
-			air.set_moles(co2, carbon);
-			air.adjust_moles(
-				byproduct_a,
-				FUSION_TRITIUM_MOLES_USED * (reaction_energy * tritium_conversion_coefficient),
-			);
-			air.adjust_moles(
-				byproduct_b,
-				FUSION_TRITIUM_MOLES_USED * (reaction_energy * tritium_conversion_coefficient),
-			);
-			if reaction_energy != 0.0 {
-				air.set_temperature((initial_energy + reaction_energy) / air.heat_capacity());
-			}
-			air.garbage_collect();
-			Ok(())
-		})?;
-		if reaction_energy != 0.0 {
-			if let Some(fusion_ball) = Proc::find(byond_string!("/proc/fusion_ball")) {
-				fusion_ball.call(&[
-					holder,
-					&Value::from(reaction_energy),
-					&Value::from(instability),
-				])?;
-			} else {
-				Proc::find(byond_string!("/proc/stack_trace"))
-					.ok_or_else(|| runtime!("Couldn't find stack_trace!"))?
-					.call(&[&Value::from_string(
-						"fusion_ball not found! Auxmos hooked fusion does not work without it!",
-					)?])?;
-			}
-			Ok(Value::from(1.0))
+
+	//To achieve faster equilibrium. Too bad it is not that good at cooling down.
+	if reaction_energy != 0.0 {
+		let middle_energy = (((TOROID_CALCULATED_THRESHOLD / 2.0) * scale_factor)
+			+ FUSION_MOLE_THRESHOLD)
+			* (200.0 * FUSION_MIDDLE_ENERGY_REFERENCE);
+		thermal_energy = middle_energy
+			* FUSION_ENERGY_TRANSLATION_EXPONENT
+			.powf((thermal_energy / middle_energy).log10());
+		//This bowdlerization is a double-edged sword. Tread with care!
+		let bowdlerized_reaction_energy = reaction_energy.clamp(
+			thermal_energy * ((1.0 / (FUSION_ENERGY_TRANSLATION_EXPONENT.powi(2))) - 1.0),
+			thermal_energy * (FUSION_ENERGY_TRANSLATION_EXPONENT.powi(2) - 1.0));
+		thermal_energy = middle_energy
+			* 10_f32.powf(((thermal_energy + bowdlerized_reaction_energy)
+			/ middle_energy).log(FUSION_ENERGY_TRANSLATION_EXPONENT))
+	};
+
+	//The decay of the tritium and the reaction's energy produces waste gases, different ones depending on whether the reaction is endo or exothermic
+	let standard_waste_gas_output = scale_factor
+		* (FUSION_TRITIUM_CONVERSION_COEFFICIENT*FUSION_TRITIUM_MOLES_USED);
+
+	let standard_energy = with_mix_mut(byond_air, |air| {
+
+		air.set_moles(plas, plasma);
+		air.set_moles(co2, carbon);
+
+		//The reason why you should set up a tritium production line.
+		air.adjust_moles(trit, -FUSION_TRITIUM_MOLES_USED);
+
+		//Adds waste products
+		if delta_plasma > 0.0 {
+			air.adjust_moles(h2o, standard_waste_gas_output);
 		} else {
-			Ok(Value::from(0.0))
+			air.adjust_moles(bz, standard_waste_gas_output);
 		}
+		air.adjust_moles(o2, standard_waste_gas_output); //Oxygen is a bit touchy subject
+
+		let new_heat_cap = air.heat_capacity();
+		let standard_energy = 400_f32 * air.get_moles(plas) * air.get_temperature(); //Prevents putting meaningless waste gases to achieve high rads.
+
+		//Change the temperature
+		if reaction_energy != 0.0 {
+			if new_heat_cap > MINIMUM_HEAT_CAPACITY{
+				air.set_temperature((thermal_energy/new_heat_cap).clamp(TCMB, INFINITY));
+			}
+		} else if reaction_energy == 0.0
+			&& instability <= FUSION_INSTABILITY_ENDOTHERMALITY {
+			if new_heat_cap > MINIMUM_HEAT_CAPACITY{
+				air.set_temperature((thermal_energy/new_heat_cap).clamp(TCMB, INFINITY)); //THIS SHOULD STAY OR FUSION WILL EAT YOUR FACE
+			}
+		}
+		air.garbage_collect();
+		Ok(standard_energy)
+	})?;
+	if reaction_energy != 0.0 {
+		Proc::find(byond_string!("/proc/fusion_ball"))
+			.unwrap()
+			.call(&[
+				holder,
+				&Value::from(reaction_energy),
+				&Value::from(standard_energy),
+			])?;
+		Ok(Value::from(1.0))
+	} else if reaction_energy == 0.0
+		&& instability <= FUSION_INSTABILITY_ENDOTHERMALITY {
+		Ok(Value::from(1.0))
+	} else {
+		Ok(Value::from(0.0))
 	}
 }
 

--- a/src/reaction/hooks.rs
+++ b/src/reaction/hooks.rs
@@ -188,6 +188,7 @@ fn fusion(byond_air: Value, holder: Value) {
 	const FUSION_BASE_TEMPSCALE:f32	= 6.0;       			// This number is responsible for orchestrating fusion temperatures
 	const FUSION_MIDDLE_ENERGY_REFERENCE:f32 = 1E+6;		// This number is deceptively dangerous; sort of tied to TOROID_CALCULATED_THRESHOLD
 	const FUSION_BUFFER_DIVISOR:f32 = 1.0;					// Increase this to cull unrobust fusions faster
+	const INFINITY:f32 = 1E+30;								// Well, infinity in byond
 	let plas = gas_idx_from_string(GAS_PLASMA)?;
 	let co2 = gas_idx_from_string(GAS_CO2)?;
 	let trit = gas_idx_from_string(GAS_TRITIUM)?;

--- a/src/turfs/monstermos.rs
+++ b/src/turfs/monstermos.rs
@@ -28,7 +28,7 @@ struct MonstermosInfo {
 impl Default for MonstermosInfo {
 	fn default() -> MonstermosInfo {
 		MonstermosInfo {
-			transfer_dirs: [ 0_f32; 7 ],
+			transfer_dirs: [0_f32; 7],
 			mole_delta: 0_f32,
 			curr_transfer_amount: 0_f32,
 			curr_transfer_dir: 6,
@@ -174,10 +174,9 @@ fn explosively_depressurize(
 	max_x: i32,
 	max_y: i32,
 ) -> DMResult {
-	let mut turfs: IndexSet<MixWithID, RandomState>
-		= IndexSet::with_hasher(RandomState::default());
-	let mut progression_order: IndexSet<MixWithID, RandomState>
-		= IndexSet::with_hasher(RandomState::default());
+	let mut turfs: IndexSet<MixWithID, RandomState> = IndexSet::with_hasher(RandomState::default());
+	let mut progression_order: IndexSet<MixWithID, RandomState> =
+		IndexSet::with_hasher(RandomState::default());
 	turfs.insert((turf_idx, turf));
 	let cur_orig = info.entry(turf_idx).or_default();
 	let mut cur_info: MonstermosInfo = Default::default();
@@ -341,14 +340,14 @@ fn flood_fill_equalize_turfs(
 ) -> Option<(
 	IndexSet<MixWithID, RandomState>,
 	IndexSet<MixWithID, RandomState>,
-	f64
+	f64,
 )> {
-	let mut turfs: IndexSet<MixWithID, RandomState>
-		= IndexSet::with_capacity_and_hasher(equalize_hard_turf_limit, RandomState::default());
-	let mut border_turfs: std::collections::VecDeque<MixWithID>
-		= std::collections::VecDeque::with_capacity(equalize_hard_turf_limit);
-	let mut planet_turfs: IndexSet<MixWithID, RandomState>
-		= IndexSet::with_hasher(RandomState::default());
+	let mut turfs: IndexSet<MixWithID, RandomState> =
+		IndexSet::with_capacity_and_hasher(equalize_hard_turf_limit, RandomState::default());
+	let mut border_turfs: std::collections::VecDeque<MixWithID> =
+		std::collections::VecDeque::with_capacity(equalize_hard_turf_limit);
+	let mut planet_turfs: IndexSet<MixWithID, RandomState> =
+		IndexSet::with_hasher(RandomState::default());
 	#[cfg(feature = "explosive_decompression")]
 	let sender = byond_callback_sender();
 	let mut total_moles = 0.0_f64;
@@ -389,7 +388,8 @@ fn flood_fill_equalize_turfs(
 									let cloned = fake_cloned
 										.iter()
 										.map(|(&k, &v)| (k, Cell::new(v)))
-										.collect::<HashMap<TurfID, Cell<MonstermosInfo>, FxBuildHasher>>();
+										.collect::<HashMap<TurfID, Cell<MonstermosInfo>, FxBuildHasher>>(
+										);
 									explosively_depressurize(
 										i,
 										m,
@@ -693,10 +693,10 @@ fn process_planet_turfs(
 				)?;
 				if let Some(adj) = turf_gases().get(&loc) {
 					if adj_info.last_slow_queue_cycle == queue_cycle_slow
-							|| adj.value().planetary_atmos.is_some()
-						{
-							continue;
-						}
+						|| adj.value().planetary_atmos.is_some()
+					{
+						continue;
+					}
 					adj_info.last_slow_queue_cycle = queue_cycle_slow;
 					adj_info.curr_transfer_dir = OPP_DIR_INDEX[j as usize];
 					adj_orig.set(adj_info);
@@ -741,12 +741,12 @@ pub(crate) fn equalize(
 	high_pressure_turfs: BTreeSet<TurfID>,
 	do_planet_atmos: bool,
 ) -> usize {
-	let mut info: HashMap<TurfID, Cell<MonstermosInfo>, FxBuildHasher>
-		= HashMap::with_hasher(FxBuildHasher::default());
+	let mut info: HashMap<TurfID, Cell<MonstermosInfo>, FxBuildHasher> =
+		HashMap::with_hasher(FxBuildHasher::default());
 	let mut turfs_processed = 0;
 	let mut queue_cycle_slow = 1;
-	let mut found_turfs: HashSet<TurfID, FxBuildHasher>
-		= HashSet::with_hasher(FxBuildHasher::default());
+	let mut found_turfs: HashSet<TurfID, FxBuildHasher> =
+		HashSet::with_hasher(FxBuildHasher::default());
 	for &i in high_pressure_turfs.iter() {
 		if found_turfs.contains(&i)
 			|| turf_gases().get(&i).map_or(true, |m| {
@@ -788,8 +788,8 @@ pub(crate) fn equalize(
 			}
 		}
 		let average_moles = (total_moles / (turfs.len() - planet_turfs.len()) as f64) as f32;
-		let mut giver_turfs:Vec<MixWithID> = Vec::new();
-		let mut taker_turfs:Vec<MixWithID> = Vec::new();
+		let mut giver_turfs: Vec<MixWithID> = Vec::new();
+		let mut taker_turfs: Vec<MixWithID> = Vec::new();
 		for &(i, m) in &turfs {
 			let cur_info = info.entry(i).or_default().get_mut();
 			cur_info.mole_delta = m.total_moles() - average_moles;
@@ -861,10 +861,11 @@ pub(crate) fn equalize(
 		} else if do_planet_atmos {
 			turfs_processed += turfs.len() + planet_turfs.len();
 			let sender = byond_callback_sender();
-			let fake_cloned = info
-				.iter()
-				.map(|(&k, v)| (k, v.get()))
-				.collect::<HashMap<TurfID, MonstermosInfo, FxBuildHasher>>();
+			let fake_cloned = info.iter().map(|(&k, v)| (k, v.get())).collect::<HashMap<
+				TurfID,
+				MonstermosInfo,
+				FxBuildHasher,
+			>>();
 			let _ = sender.send(Box::new(move || {
 				let mut cloned = fake_cloned
 					.iter()


### PR DESCRIPTION
Includes and thus closes #26.

Generic fires now have the ability to release radiation with arbitrary reagents.

Generic fires have been reworked to use a more proper enthalpy bookkeeping system, i.e. how much they heat up or cool down is based on how much energy it takes their reagents to separate and combine.

Other changes mostly due to cargo fmt, which I should definitely start enforcing.