### PR TITLE
prevents katmos from spamming firelock checks on planet atmos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
  "auxcleanup",
  "auxtools",
  "crossbeam",
- "dashmap 4.0.2",
+ "dashmap 5.0.0",
  "float-ord",
  "flume",
  "fxhash",
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "auxtools"
 version = "0.1.0"
-source = "git+https://github.com/willox/auxtools#a4b08d61e14e5e7f392e40063abbe7487fd50ec7"
+source = "git+https://github.com/willox/auxtools#4bf1c1c4697981e5b975bc69535e28c3133e1956"
 dependencies = [
  "auxtools-impl",
  "cc",
@@ -101,7 +101,7 @@ dependencies = [
 [[package]]
 name = "auxtools-impl"
 version = "0.1.0"
-source = "git+https://github.com/willox/auxtools#a4b08d61e14e5e7f392e40063abbe7487fd50ec7"
+source = "git+https://github.com/willox/auxtools#4bf1c1c4697981e5b975bc69535e28c3133e1956"
 dependencies = [
  "hex",
  "proc-macro2",
@@ -117,9 +117,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -264,12 +264,13 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+checksum = "b799062aaf67eb976af3bdca031ee6f846d2f0a5710ddbb0d2efee33f3cc4760"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
+ "parking_lot",
 ]
 
 [[package]]
@@ -302,9 +303,9 @@ checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "flume"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c3fd473b3a903a62609e413ed7538f99e10b665ecb502b5e481a95283f8ab4"
+checksum = "5d04dafd11240188e146b6f6476a898004cace3be31d4ec5e08e216bf4947ac0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -345,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -390,9 +391,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -441,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -466,9 +467,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libudis86-sys"
@@ -482,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -585,18 +586,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -611,18 +612,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -687,9 +688,9 @@ checksum = "733fc6e5f1bd3a8136f842c9bdea4e5f17c910c2fcc98c90c3aa7604ef5e2e7a"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "spin"
@@ -702,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1dfb999630e338648c83e91c59a4e9fb7620f520c3194b6b89e276f2f1959"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -737,9 +738,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-xid"
@@ -749,9 +750,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -761,9 +762,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -771,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -786,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -796,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -809,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ indexmap = { version = "1.7.0", features = ["rayon"] }
 ahash = "0.7.6"
 
 [dependencies.dashmap]
-version = "4.0.2"
+version = "5.0.0"
 features = ["raw-api"]
 
 [dependencies.tinyvec]

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -1,11 +1,16 @@
-
 //Monstermos, but zoned, and multithreaded!
 
 use super::*;
 
-use std::{cell::Cell, {collections::{BTreeSet, HashMap, HashSet}, sync::atomic::AtomicUsize}};
+use std::{
+	cell::Cell,
+	{
+		collections::{BTreeSet, HashMap, HashSet},
+		sync::atomic::AtomicUsize,
+	},
+};
 
-use indexmap::{IndexSet, IndexMap};
+use indexmap::{IndexMap, IndexSet};
 
 use ahash::RandomState;
 use fxhash::FxBuildHasher;
@@ -32,7 +37,7 @@ struct MonstermosInfo {
 impl Default for MonstermosInfo {
 	fn default() -> MonstermosInfo {
 		MonstermosInfo {
-			transfer_dirs: [ 0_f32; 7 ],
+			transfer_dirs: [0_f32; 7],
 			mole_delta: 0_f32,
 			curr_transfer_amount: 0_f32,
 			curr_transfer_dir: 6,
@@ -101,9 +106,9 @@ impl Iterator for AdjacentTileIDsNoorig {
 	}
 }
 
-impl FusedIterator for  AdjacentTileIDsNoorig {}
+impl FusedIterator for AdjacentTileIDsNoorig {}
 
-fn adjacent_tile_ids_no_orig(adj: u8, i: TurfID, max_x: i32, max_y: i32) ->  AdjacentTileIDsNoorig {
+fn adjacent_tile_ids_no_orig(adj: u8, i: TurfID, max_x: i32, max_y: i32) -> AdjacentTileIDsNoorig {
 	AdjacentTileIDsNoorig {
 		adj,
 		i,
@@ -207,7 +212,7 @@ fn finalize_eq_neighbors(
 		let amount = transfer_dirs[j as usize];
 		if amount < 0.0 {
 			let other_turf = {
-				let maybe =	turfs.get(&adjacent_id);
+				let maybe = turfs.get(&adjacent_id);
 				if maybe.is_none() {
 					continue;
 				}
@@ -217,8 +222,6 @@ fn finalize_eq_neighbors(
 		}
 	}
 }
-
-
 
 fn monstermos_fast_process(
 	i: &TurfID,
@@ -240,7 +243,7 @@ fn monstermos_fast_process(
 	let mut eligible_adjacents: u8 = 0;
 	if cur_info.mole_delta > 0.0 {
 		for (j, loc) in adjacent_tile_ids_no_orig(m.adjacency, *i, max_x, max_y) {
-			if turfs.get(&loc).map_or(false,|thin| thin.enabled() ) {
+			if turfs.get(&loc).map_or(false, |thin| thin.enabled()) {
 				if let Some(adj_info) = info.get(&loc) {
 					if !adj_info.fast_done {
 						eligible_adjacents |= 1 << j;
@@ -250,7 +253,7 @@ fn monstermos_fast_process(
 		}
 		let amt_eligible = eligible_adjacents.count_ones();
 		if amt_eligible == 0 {
-			info.entry(*i).and_modify(|entry| { *entry = cur_info });
+			info.entry(*i).and_modify(|entry| *entry = cur_info);
 			return;
 		}
 		let moles_to_move = cur_info.mole_delta / amt_eligible as f32;
@@ -260,7 +263,7 @@ fn monstermos_fast_process(
 				cur_info.mole_delta -= moles_to_move;
 				adj_info.mole_delta += moles_to_move;
 			}
-			info.entry(*i).and_modify(|entry| { *entry = cur_info });
+			info.entry(*i).and_modify(|entry| *entry = cur_info);
 		}
 	}
 }
@@ -273,7 +276,8 @@ fn give_to_takers(
 	max_y: i32,
 	info: &DashMap<TurfID, MonstermosInfo, FxBuildHasher>,
 ) {
-	let mut queue: IndexMap<TurfID, &TurfMixture, FxBuildHasher> = IndexMap::with_hasher(FxBuildHasher::default());
+	let mut queue: IndexMap<TurfID, &TurfMixture, FxBuildHasher> =
+		IndexMap::with_hasher(FxBuildHasher::default());
 
 	for (i, m) in giver_turfs {
 		let mut giver_info = {
@@ -297,8 +301,9 @@ fn give_to_takers(
 					break;
 				}
 				if let Some(mut adj_info) = info.get_mut(&loc) {
-					if let Some(adj_mix) =
-						turfs.get(&loc).map_or(None, |terf| { terf.enabled().then(|| terf) })
+					if let Some(adj_mix) = turfs
+						.get(&loc)
+						.map_or(None, |terf| terf.enabled().then(|| terf))
 					{
 						if let None = queue.insert(loc, adj_mix) {
 							adj_info.curr_transfer_dir = OPP_DIR_INDEX[j as usize];
@@ -320,7 +325,7 @@ fn give_to_takers(
 						}
 					}
 				}
-				info.entry(*i).and_modify(|entry| { *entry = giver_info });
+				info.entry(*i).and_modify(|entry| *entry = giver_info);
 			}
 			queue_idx += 1;
 		}
@@ -333,12 +338,9 @@ fn give_to_takers(
 						max_x,
 						max_y,
 					)) {
-						let (dir, amt) = (turf_info.curr_transfer_dir, turf_info.curr_transfer_amount);
-						turf_info.adjust_eq_movement(
-							Some(&mut adj_info),
-							dir,
-							amt,
-						);
+						let (dir, amt) =
+							(turf_info.curr_transfer_dir, turf_info.curr_transfer_amount);
+						turf_info.adjust_eq_movement(Some(&mut adj_info), dir, amt);
 						adj_info.curr_transfer_amount += turf_info.curr_transfer_amount;
 						turf_info.curr_transfer_amount = 0.0;
 					}
@@ -356,7 +358,8 @@ fn take_from_givers(
 	max_y: i32,
 	info: &DashMap<TurfID, MonstermosInfo, FxBuildHasher>,
 ) {
-	let mut queue: IndexMap<TurfID, &TurfMixture, FxBuildHasher> = IndexMap::with_hasher(FxBuildHasher::default());
+	let mut queue: IndexMap<TurfID, &TurfMixture, FxBuildHasher> =
+		IndexMap::with_hasher(FxBuildHasher::default());
 
 	for (i, m) in taker_turfs {
 		let mut taker_info = {
@@ -380,8 +383,9 @@ fn take_from_givers(
 					break;
 				}
 				if let Some(mut adj_info) = info.get_mut(&loc) {
-					if let Some(adj_mix) =
-						turfs.get(&loc).map_or(None, |terf| { terf.enabled().then(|| terf) })
+					if let Some(adj_mix) = turfs
+						.get(&loc)
+						.map_or(None, |terf| terf.enabled().then(|| terf))
 					{
 						if let None = queue.insert(loc, adj_mix) {
 							adj_info.curr_transfer_dir = OPP_DIR_INDEX[j as usize];
@@ -403,7 +407,7 @@ fn take_from_givers(
 						}
 					}
 				}
-				info.entry(*i).and_modify(|entry| { *entry = taker_info });
+				info.entry(*i).and_modify(|entry| *entry = taker_info);
 			}
 			queue_idx += 1;
 		}
@@ -416,12 +420,9 @@ fn take_from_givers(
 						max_x,
 						max_y,
 					)) {
-						let (dir, amt) = (turf_info.curr_transfer_dir, turf_info.curr_transfer_amount);
-						turf_info.adjust_eq_movement(
-							Some(&mut adj_info),
-							dir,
-							amt,
-						);
+						let (dir, amt) =
+							(turf_info.curr_transfer_dir, turf_info.curr_transfer_amount);
+						turf_info.adjust_eq_movement(Some(&mut adj_info), dir, amt);
 						adj_info.curr_transfer_amount += turf_info.curr_transfer_amount;
 						turf_info.curr_transfer_amount = 0.0;
 					}
@@ -431,21 +432,20 @@ fn take_from_givers(
 	}
 }
 
-
 fn explosively_depressurize(
 	turf_idx: TurfID,
 	max_x: i32,
 	max_y: i32,
 	equalize_hard_turf_limit: usize,
 ) -> DMResult {
-	let mut info: HashMap<TurfID, Cell<ReducedInfo>, FxBuildHasher>
-		= HashMap::with_hasher(FxBuildHasher::default());
-	let mut turfs: IndexSet<TurfID, FxBuildHasher>
-		= IndexSet::with_hasher(FxBuildHasher::default());
-	let mut progression_order: IndexSet<MixWithID, RandomState>
-		= IndexSet::with_hasher(RandomState::default());
-	let mut space_turfs: IndexSet<TurfID, FxBuildHasher>
-		= IndexSet::with_hasher(FxBuildHasher::default());
+	let mut info: HashMap<TurfID, Cell<ReducedInfo>, FxBuildHasher> =
+		HashMap::with_hasher(FxBuildHasher::default());
+	let mut turfs: IndexSet<TurfID, FxBuildHasher> =
+		IndexSet::with_hasher(FxBuildHasher::default());
+	let mut progression_order: IndexSet<MixWithID, RandomState> =
+		IndexSet::with_hasher(RandomState::default());
+	let mut space_turfs: IndexSet<TurfID, FxBuildHasher> =
+		IndexSet::with_hasher(FxBuildHasher::default());
 	turfs.insert(turf_idx);
 	let mut warned_about_planet_atmos = false;
 	let mut cur_queue_idx = 0;
@@ -613,15 +613,14 @@ fn flood_fill_equalize_turfs(
 	found_turfs: &mut HashSet<TurfID, FxBuildHasher>,
 ) -> Option<(
 	IndexMap<TurfID, TurfMixture, FxBuildHasher>,
-	IndexMap<TurfID, TurfMixture, FxBuildHasher>, f64
-	)>
-{
-	let mut turfs: IndexMap<TurfID, TurfMixture, FxBuildHasher>
-		= IndexMap::with_hasher(FxBuildHasher::default());
-	let mut border_turfs: std::collections::VecDeque<MixWithID>
-		= std::collections::VecDeque::new();
-	let mut planet_turfs: IndexMap<TurfID, TurfMixture, FxBuildHasher>
-		= IndexMap::with_hasher(FxBuildHasher::default());
+	IndexMap<TurfID, TurfMixture, FxBuildHasher>,
+	f64,
+)> {
+	let mut turfs: IndexMap<TurfID, TurfMixture, FxBuildHasher> =
+		IndexMap::with_hasher(FxBuildHasher::default());
+	let mut border_turfs: std::collections::VecDeque<MixWithID> = std::collections::VecDeque::new();
+	let mut planet_turfs: IndexMap<TurfID, TurfMixture, FxBuildHasher> =
+		IndexMap::with_hasher(FxBuildHasher::default());
 	let sender = byond_callback_sender();
 	let mut total_moles = 0.0_f64;
 	border_turfs.push_back((i, m));
@@ -637,23 +636,24 @@ fn flood_fill_equalize_turfs(
 			for (_, loc) in adjacent_tile_ids(cur_turf.adjacency, cur_idx, max_x, max_y) {
 				if found_turfs.insert(loc) {
 					if let Some(adj_turf) = turf_gases().get(&loc) {
-							if adj_turf.enabled() {
-								border_turfs.push_back((loc, *adj_turf.value()));
+						if adj_turf.enabled() {
+							border_turfs.push_back((loc, *adj_turf.value()));
+						}
+						if adj_turf.value().is_immutable() {
+							// Uh oh! looks like someone opened an airlock to space! TIME TO SUCK ALL THE AIR OUT!!!
+							// NOT ONE OF YOU IS GONNA SURVIVE THIS
+							// (I just made explosions less laggy, you're welcome)
+							if !space_this_time {
+								let _ = sender.send(Box::new(move || {
+									explosively_depressurize(
+										i,
+										max_x,
+										max_y,
+										equalize_hard_turf_limit,
+									)
+								}));
 							}
-							if adj_turf.value().is_immutable() {
-								// Uh oh! looks like someone opened an airlock to space! TIME TO SUCK ALL THE AIR OUT!!!
-								// NOT ONE OF YOU IS GONNA SURVIVE THIS
-								// (I just made explosions less laggy, you're welcome)
-								if !space_this_time {
-									let _ = sender.send(Box::new(move || {
-										explosively_depressurize(
-											i,
-											max_x,
-											max_y,
-											equalize_hard_turf_limit)
-									}));
-								}
-								space_this_time = true;
+							space_this_time = true;
 						}
 					}
 				}
@@ -681,14 +681,15 @@ fn process_planet_turfs(
 	if sample_planet_atmos.is_none() {
 		return;
 	}
-	let maybe_planet_sum = planetary_atmos().get( &sample_planet_atmos.unwrap() );
+	let maybe_planet_sum = planetary_atmos().get(&sample_planet_atmos.unwrap());
 	if maybe_planet_sum.is_none() {
 		return;
 	}
 	let planet_sum = maybe_planet_sum.unwrap().value().total_moles();
 	let target_delta = planet_sum - average_moles;
 
-	let mut progression_order: IndexSet<TurfID, FxBuildHasher> = IndexSet::with_hasher(FxBuildHasher::default());
+	let mut progression_order: IndexSet<TurfID, FxBuildHasher> =
+		IndexSet::with_hasher(FxBuildHasher::default());
 
 	for (i, _) in planet_turfs.iter() {
 		progression_order.insert(*i);
@@ -702,31 +703,28 @@ fn process_planet_turfs(
 		queue_idx += 1;
 		let maybe_m = turfs.get(&i);
 		if maybe_m.is_none() {
-			info.entry(i).and_modify(|entry| *entry = MonstermosInfo::default());
+			info.entry(i)
+				.and_modify(|entry| *entry = MonstermosInfo::default());
 			continue;
 		}
 		let m = *maybe_m.unwrap();
 		for (j, loc) in adjacent_tile_ids_no_orig(m.adjacency, i, max_x, max_y) {
 			if let Some(mut adj_info) = info.get_mut(&loc) {
 				if queue_idx < equalize_hard_turf_limit {
-						let _ = sender.try_send(Box::new(move || {
+					let _ = sender.try_send(Box::new(move || {
 						let that_turf = unsafe { Value::turf_by_id_unchecked(loc) };
 						let this_turf = unsafe { Value::turf_by_id_unchecked(i) };
-						this_turf.call(
-							"consider_firelocks",
-							&[&that_turf],
-						)?;
+						this_turf.call("consider_firelocks", &[&that_turf])?;
 						Ok(Value::null())
 					}));
 				}
-				if let Some(adj) =
-					turfs.get(&loc).map_or(None, |terf| { terf.enabled().then(|| terf) })
+				if let Some(adj) = turfs
+					.get(&loc)
+					.map_or(None, |terf| terf.enabled().then(|| terf))
 				{
-					if !progression_order.insert(loc)
-							|| adj.planetary_atmos.is_some()
-						{
-							continue;
-						}
+					if !progression_order.insert(loc) || adj.planetary_atmos.is_some() {
+						continue;
+					}
 					adj_info.curr_transfer_dir = OPP_DIR_INDEX[j as usize];
 				}
 			}
@@ -756,7 +754,6 @@ fn process_planet_turfs(
 	}
 }
 
-
 pub(crate) fn equalize(
 	max_x: i32,
 	max_y: i32,
@@ -764,117 +761,103 @@ pub(crate) fn equalize(
 	high_pressure_turfs: &BTreeSet<TurfID>,
 ) -> usize {
 	let turfs_processed: AtomicUsize = AtomicUsize::new(0);
-	let mut found_turfs: HashSet<TurfID, FxBuildHasher>
-		= HashSet::with_hasher(FxBuildHasher::default());
-	let zoned_turfs =
-		high_pressure_turfs
-			.iter()
-			.filter_map(|i| {
-				if found_turfs.contains(&i)
-					|| turf_gases().get(&i).map_or(true, |m| {
-						!m.enabled()
-							|| m.adjacency <= 0 || GasArena::with_all_mixtures(|all_mixtures| {
-							let our_moles = all_mixtures[m.mix].read().total_moles();
-							our_moles < 10.0
-								|| m.adjacent_mixes(all_mixtures).all(|lock| {
-									(lock.read().total_moles() - our_moles).abs()
-										< MINIMUM_MOLES_DELTA_TO_MOVE
-								})
-						})
-					}) {
-					return None;
+	let mut found_turfs: HashSet<TurfID, FxBuildHasher> =
+		HashSet::with_hasher(FxBuildHasher::default());
+	let zoned_turfs = high_pressure_turfs
+		.iter()
+		.filter_map(|i| {
+			if found_turfs.contains(&i)
+				|| turf_gases().get(&i).map_or(true, |m| {
+					!m.enabled()
+						|| m.adjacency <= 0 || GasArena::with_all_mixtures(|all_mixtures| {
+						let our_moles = all_mixtures[m.mix].read().total_moles();
+						our_moles < 10.0
+							|| m.adjacent_mixes(all_mixtures).all(|lock| {
+								(lock.read().total_moles() - our_moles).abs()
+									< MINIMUM_MOLES_DELTA_TO_MOVE
+							})
+					})
+				}) {
+				return None;
+			}
+			let maybe_m = turf_gases().get(&i);
+			if maybe_m.is_none() {
+				return None;
+			}
+			let m = *maybe_m.unwrap();
+			flood_fill_equalize_turfs(
+				*i,
+				m,
+				max_x,
+				max_y,
+				equalize_hard_turf_limit,
+				&mut found_turfs,
+			)
+		})
+		.collect::<Vec<_>>();
+
+	let turfs = zoned_turfs
+		.into_par_iter()
+		.map(|(turfs, planet_turfs, total_moles)| {
+			let info: DashMap<TurfID, MonstermosInfo, FxBuildHasher> =
+				DashMap::with_hasher(FxBuildHasher::default());
+			let average_moles = (total_moles / (turfs.len() - planet_turfs.len()) as f64) as f32;
+
+			let (mut giver_turfs, mut taker_turfs): (Vec<_>, Vec<_>) = turfs
+				.par_iter()
+				.filter(|&(i, m)| {
+					{
+						let mut cur_info = info.entry(*i).or_default();
+						cur_info.mole_delta = m.total_moles() - average_moles;
+					}
+					m.planetary_atmos.is_none()
+				})
+				.partition(|&(i, _)| info.entry(*i).or_default().mole_delta > 0.0);
+
+			let log_n = ((turfs.len() as f32).log2().floor()) as usize;
+			if giver_turfs.len() > log_n && taker_turfs.len() > log_n {
+				for (i, m) in &turfs {
+					monstermos_fast_process(i, m, &turfs, max_x, max_y, &info);
 				}
-				let maybe_m = turf_gases().get(&i);
-				if maybe_m.is_none() {
-					return None;
-				}
-				let m = *maybe_m.unwrap();
-				flood_fill_equalize_turfs(
-					*i,
-					m,
+				giver_turfs.clear();
+				taker_turfs.clear();
+
+				giver_turfs.par_extend(turfs.par_iter().filter(|&(i, m)| {
+					info.entry(*i).or_default().mole_delta > 0.0 && m.planetary_atmos.is_none()
+				}));
+
+				taker_turfs.par_extend(turfs.par_iter().filter(|&(i, m)| {
+					info.entry(*i).or_default().mole_delta <= 0.0 && m.planetary_atmos.is_none()
+				}));
+			}
+
+			// alright this is the part that can become O(n^2).
+			if giver_turfs.len() < taker_turfs.len() {
+				// as an optimization, we choose one of two methods based on which list is smaller.
+				give_to_takers(giver_turfs, taker_turfs, &turfs, max_x, max_y, &info);
+			} else {
+				take_from_givers(taker_turfs, giver_turfs, &turfs, max_x, max_y, &info);
+			}
+			if !planet_turfs.is_empty() {
+				turfs_processed.fetch_add(
+					turfs.len() + planet_turfs.len(),
+					std::sync::atomic::Ordering::SeqCst,
+				);
+				process_planet_turfs(
+					planet_turfs,
+					&turfs,
+					average_moles,
 					max_x,
 					max_y,
 					equalize_hard_turf_limit,
-					&mut found_turfs,
-				)})
-			.collect::<Vec<_>>();
-
-	let turfs =
-		zoned_turfs
-			.into_par_iter()
-			.map(|(turfs, planet_turfs, total_moles)| {
-				let info: DashMap<TurfID, MonstermosInfo, FxBuildHasher> = DashMap::with_hasher(FxBuildHasher::default());
-				let average_moles = (total_moles / (turfs.len() - planet_turfs.len()) as f64) as f32;
-
-				let (mut giver_turfs, mut taker_turfs): (Vec<_>, Vec<_>) =
-					turfs
-						.par_iter()
-						.filter(|&(i ,m)| {
-							{
-								let mut cur_info = info.entry(*i).or_default();
-								cur_info.mole_delta = m.total_moles() - average_moles;
-							}
-							m.planetary_atmos.is_none()
-						})
-						.partition(|&(i, _)| {
-							info.entry(*i).or_default().mole_delta > 0.0
-						});
-
-				let log_n = ((turfs.len() as f32).log2().floor()) as usize;
-				if giver_turfs.len() > log_n && taker_turfs.len() > log_n {
-					for (i, m) in &turfs {
-						monstermos_fast_process(i, m, &turfs, max_x, max_y, &info);
-					}
-					giver_turfs.clear();
-					taker_turfs.clear();
-
-					giver_turfs.par_extend(turfs.par_iter().filter(|&(i, m)| {
-						info.entry(*i).or_default().mole_delta > 0.0 && m.planetary_atmos.is_none()
-					}));
-
-					taker_turfs.par_extend(turfs.par_iter().filter(|&(i, m)| {
-						info.entry(*i).or_default().mole_delta <= 0.0 && m.planetary_atmos.is_none()
-					}));
-
-				}
-
-				// alright this is the part that can become O(n^2).
-				if giver_turfs.len() < taker_turfs.len() {
-					// as an optimization, we choose one of two methods based on which list is smaller.
-					give_to_takers(
-						giver_turfs,
-						taker_turfs,
-						&turfs,
-						max_x,
-						max_y,
-						&info,
-					);
-				} else {
-					take_from_givers(
-						taker_turfs,
-						giver_turfs,
-						&turfs,
-						max_x,
-						max_y,
-						&info,
-					);
-				}
-				if !planet_turfs.is_empty() {
-					turfs_processed.fetch_add(turfs.len() + planet_turfs.len(), std::sync::atomic::Ordering::SeqCst);
-					process_planet_turfs(
-						planet_turfs,
-						&turfs,
-						average_moles,
-						max_x,
-						max_y,
-						equalize_hard_turf_limit,
-						&info,
-					);
-				} else {
-					turfs_processed.fetch_add(turfs.len(), std::sync::atomic::Ordering::SeqCst);
-				}
-				(turfs, info)})
-			.collect::<Vec<_>>();
+					&info,
+				);
+			} else {
+				turfs_processed.fetch_add(turfs.len(), std::sync::atomic::Ordering::SeqCst);
+			}
+			(turfs, info)
+		})
+		.collect::<Vec<_>>();
 
 	turfs.par_iter().for_each(|(turf, info)| {
 		turf.iter().for_each(|(i, m)| {
@@ -883,5 +866,3 @@ pub(crate) fn equalize(
 	});
 	turfs_processed.load(std::sync::atomic::Ordering::Relaxed)
 }
-
-


### PR DESCRIPTION
limits firelock checks range to equalize_hard_turf_limit, like decomp does