### PR TITLE
adds some fairly basic logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "auxcleanup",
  "auxtools",
  "backtrace",
+ "chrono",
  "crossbeam",
  "dashmap 5.0.0",
  "float-ord",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,6 +36,12 @@ dependencies = [
  "once_cell",
  "version_check",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "autocfg"
@@ -66,6 +87,7 @@ name = "auxmos"
 version = "0.2.0"
 dependencies = [
  "ahash 0.7.6",
+ "anyhow",
  "auxcallback",
  "auxcleanup",
  "auxtools",
@@ -76,10 +98,14 @@ dependencies = [
  "fxhash",
  "indexmap",
  "itertools",
+ "log",
+ "log-panics",
  "nonmax",
  "parking_lot",
  "rayon",
+ "simple-logging",
  "tinyvec",
+ "vergen",
 ]
 
 [[package]]
@@ -110,6 +136,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +173,9 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -144,6 +188,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "const-random"
@@ -296,6 +353,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "float-ord"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +389,16 @@ dependencies = [
  "nanorand",
  "pin-project",
  "spin",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -358,6 +445,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ghost"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +465,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
+name = "git2"
+version = "0.13.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -388,6 +506,17 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indexmap"
@@ -441,6 +570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +610,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.26+1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libudis86-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +629,18 @@ checksum = "139bbf9ddb1bfc90c1ac64dd2923d9c957cd433cee7315c018125d72ab08a6b0"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -500,6 +662,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "log-panics"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0136257df209261daa18d6c16394757c63e032e27aafd8b07788b051082bef"
+dependencies = [
+ "backtrace",
+ "log",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,11 +681,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
  "autocfg",
 ]
 
@@ -544,6 +738,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287a6d20c39e398d0046fd7809c83fd3a12d42a3a0f4612f5028a8f5b5c4d0ce"
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +764,15 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -579,10 +801,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "smallvec",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
@@ -602,6 +830,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -655,6 +913,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -675,10 +939,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "simple-logging"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00d48e85675326bb182a2286ea7c1a0b264333ae10f27a937a72be08628b542"
+dependencies = [
+ "lazy_static",
+ "log",
+ "thread-id",
+]
 
 [[package]]
 name = "slice-pool"
@@ -713,6 +1000,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread-id"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+dependencies = [
+ "libc",
+ "redox_syscall 0.1.57",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,10 +1071,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3893329bee75c101278e0234b646fa72221547d63f97fb66ac112a0569acd110"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "chrono",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustversion",
+ "thiserror",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "auxcallback",
  "auxcleanup",
  "auxtools",
+ "backtrace",
  "crossbeam",
  "dashmap 5.0.0",
  "float-ord",
@@ -99,7 +100,6 @@ dependencies = [
  "indexmap",
  "itertools",
  "log",
- "log-panics",
  "nonmax",
  "parking_lot",
  "rayon",
@@ -659,16 +659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "log-panics"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0136257df209261daa18d6c16394757c63e032e27aafd8b07788b051082bef"
-dependencies = [
- "backtrace",
- "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 
 [features]
 default = ["auxcleanup_gas_deletion", "logging"]
-logging = ["simple-logging", "log", "backtrace"]
+logging = ["simple-logging", "log", "backtrace", "chrono"]
 auxcleanup_gas_deletion = ["auxcleanup"]
 equalization = []
 monstermos = ["equalization"]
@@ -41,9 +41,12 @@ fxhash = "0.2.1"
 nonmax = "0.5.0"
 indexmap = { version = "1.7.0", features = ["rayon"] }
 ahash = "0.7.6"
+
+#Logging features
 simple-logging = { version = "2.0.2", optional = true }
 log = { version = "0.4.14", optional = true }
 backtrace = { version = "0.3.63", optional = true }
+chrono = {  version = "0.4.19", optional = true, features = ["alloc", "clock"] }
 
 [build-dependencies]
 vergen = { version = "6", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 
 [features]
 default = ["auxcleanup_gas_deletion", "logging"]
-logging = ["simple-logging", "log", "log-panics"]
+logging = ["simple-logging", "log", "backtrace"]
 auxcleanup_gas_deletion = ["auxcleanup"]
 equalization = []
 monstermos = ["equalization"]
@@ -43,7 +43,7 @@ indexmap = { version = "1.7.0", features = ["rayon"] }
 ahash = "0.7.6"
 simple-logging = { version = "2.0.2", optional = true }
 log = { version = "0.4.14", optional = true }
-log-panics = { version = "2.0.0", features = ["with-backtrace"], optional = true }
+backtrace = { version = "0.3.63", optional = true }
 
 [build-dependencies]
 vergen = { version = "6", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,13 @@ name = "auxmos"
 version = "0.2.0"
 authors = ["Putnam <putnam3145@gmail.com>"]
 edition = "2018"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["auxcleanup_gas_deletion"]
+default = ["auxcleanup_gas_deletion", "logging"]
+logging = ["simple-logging", "log", "log-panics"]
 auxcleanup_gas_deletion = ["auxcleanup"]
 equalization = []
 monstermos = ["equalization"]
@@ -39,6 +41,13 @@ fxhash = "0.2.1"
 nonmax = "0.5.0"
 indexmap = { version = "1.7.0", features = ["rayon"] }
 ahash = "0.7.6"
+simple-logging = { version = "2.0.2", optional = true }
+log = { version = "0.4.14", optional = true }
+log-panics = { version = "2.0.0", features = ["with-backtrace"], optional = true }
+
+[build-dependencies]
+vergen = { version = "6", default-features = false, features = ["git"] }
+anyhow = "1.0.52"
 
 [dependencies.dashmap]
 version = "5.0.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+use vergen::{vergen, Config};
+
+fn main() -> Result<()> {
+	vergen(Config::default())
+}

--- a/src/gas/types.rs
+++ b/src/gas/types.rs
@@ -243,7 +243,7 @@ fn _destroy_gas_info_structs() {
 #[hook("/proc/_auxtools_register_gas")]
 fn _hook_register_gas(gas: Value) {
 	let gas_id = gas.get_string(byond_string!("id"))?;
-	let gas_cache = GasType::new(gas, TOTAL_NUM_GASES.load(Ordering::Relaxed))?;
+	let gas_cache = GasType::new(&gas, TOTAL_NUM_GASES.load(Ordering::Relaxed))?;
 	unsafe { GAS_INFO_BY_STRING.as_ref() }
 		.unwrap()
 		.insert(gas_id.into_boxed_str(), gas_cache.clone());
@@ -269,7 +269,7 @@ fn _hook_init() {
 			&mut vec![data.get(data.get(i)?)?],
 		)?;
 	}
-	REACTION_INFO.write().insert(get_reaction_info());
+	let _ = REACTION_INFO.write().insert(get_reaction_info());
 	Ok(Value::from(true))
 }
 
@@ -289,7 +289,7 @@ fn get_reaction_info() -> Vec<Reaction> {
 
 #[hook("/datum/controller/subsystem/air/proc/auxtools_update_reactions")]
 fn _update_reactions() {
-	REACTION_INFO.write().insert(get_reaction_info());
+	let _ = REACTION_INFO.write().insert(get_reaction_info());
 	Ok(Value::from(true))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,24 +15,11 @@ use reaction::react_by_id;
 use gas::constants::*;
 
 #[cfg(feature = "logging")]
-use log::LevelFilter;
-
-#[cfg(feature = "logging")]
+#[macro_use]
 extern crate log;
 
 #[cfg(feature = "logging")]
-#[init(full)]
-pub fn log_init() -> Result<(), String> {
-	simple_logging::log_to_file("auxmos.log", LevelFilter::Debug).unwrap();
-
-	log_panics::init();
-
-	log::info!("Log started!");
-	log::info!("Commit hash: {}", env!("VERGEN_GIT_SHA"));
-	log::info!("Branch: {}", env!("VERGEN_GIT_BRANCH"));
-
-	Ok(())
-}
+pub mod panics;
 
 #[hook("/proc/process_atmos_callbacks")]
 fn _atmos_callback_handle() {

--- a/src/panics.rs
+++ b/src/panics.rs
@@ -5,6 +5,7 @@ use std::thread;
 use auxtools::*;
 use log::LevelFilter;
 use backtrace::Backtrace;
+use chrono::*;
 
 struct Shim(Backtrace);
 
@@ -17,7 +18,8 @@ impl fmt::Debug for Shim {
 #[init(full)]
 pub fn log_init() -> Result<(), String> {
 	panic::set_hook(Box::new(|info| {
-		simple_logging::log_to_file("auxmos.log", LevelFilter::Debug).unwrap();
+		let now = Local::now().to_rfc3339();
+		simple_logging::log_to_file(format!("auxmos-logs/{}-auxmos.log", now), LevelFilter::Debug).unwrap();
 		log::info!("Commit hash: {}", env!("VERGEN_GIT_SHA"));
 		log::info!("Branch: {}", env!("VERGEN_GIT_BRANCH"));
 

--- a/src/panics.rs
+++ b/src/panics.rs
@@ -1,0 +1,67 @@
+use auxtools::*;
+
+use log::LevelFilter;
+
+extern crate log;
+
+extern crate backtrace;
+
+use std::fmt;
+use std::panic;
+use std::thread;
+
+use backtrace::Backtrace;
+
+struct Shim(Backtrace);
+
+impl fmt::Debug for Shim {
+	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+		write!(fmt, "\n{:?}", self.0)
+	}
+}
+
+#[init(full)]
+pub fn log_init() -> Result<(), String> {
+	panic::set_hook(Box::new(|info| {
+		simple_logging::log_to_file("auxmos.log", LevelFilter::Debug).unwrap();
+		log::info!("Commit hash: {}", env!("VERGEN_GIT_SHA"));
+		log::info!("Branch: {}", env!("VERGEN_GIT_BRANCH"));
+
+		let backtrace = Backtrace::new();
+
+		let thread = thread::current();
+		let thread = thread.name().unwrap_or("unnamed");
+
+		let msg = match info.payload().downcast_ref::<&'static str>() {
+			Some(s) => *s,
+			None => match info.payload().downcast_ref::<String>() {
+				Some(s) => &**s,
+				None => "Box<Any>",
+			},
+		};
+
+		match info.location() {
+			Some(location) => {
+				error!(
+					target: "panic", "thread '{}' panicked at '{}': {}:{}{:?}",
+					thread,
+					msg,
+					location.file(),
+					location.line(),
+					Shim(backtrace)
+				);
+			}
+			None => {
+				error!(
+					target: "panic",
+					"thread '{}' panicked at '{}'{:?}",
+					thread,
+					msg,
+					Shim(backtrace)
+				)
+			}
+		}
+	}));
+
+	Ok(())
+}

--- a/src/panics.rs
+++ b/src/panics.rs
@@ -1,15 +1,9 @@
-use auxtools::*;
-
-use log::LevelFilter;
-
-extern crate log;
-
-extern crate backtrace;
-
 use std::fmt;
 use std::panic;
 use std::thread;
 
+use auxtools::*;
+use log::LevelFilter;
 use backtrace::Backtrace;
 
 struct Shim(Backtrace);

--- a/src/panics.rs
+++ b/src/panics.rs
@@ -3,9 +3,9 @@ use std::panic;
 use std::thread;
 
 use auxtools::*;
-use log::LevelFilter;
 use backtrace::Backtrace;
 use chrono::*;
+use log::LevelFilter;
 
 struct Shim(Backtrace);
 
@@ -18,8 +18,11 @@ impl fmt::Debug for Shim {
 #[init(full)]
 pub fn log_init() -> Result<(), String> {
 	panic::set_hook(Box::new(|info| {
-		let now = Local::now().to_rfc3339();
-		simple_logging::log_to_file(format!("auxmos-logs/{}-auxmos.log", now), LevelFilter::Debug).unwrap();
+		simple_logging::log_to_file(
+			format!("{}-auxmos.log", Local::now().format("%F-%H-%M-%S")),
+			LevelFilter::Debug,
+		)
+		.unwrap();
 		log::info!("Commit hash: {}", env!("VERGEN_GIT_SHA"));
 		log::info!("Branch: {}", env!("VERGEN_GIT_BRANCH"));
 

--- a/src/reaction/hooks.rs
+++ b/src/reaction/hooks.rs
@@ -203,7 +203,7 @@ fn fusion(byond_air: Value, holder: Value) {
 		scale_factor,
 		temperature_scale,
 		gas_power,
-	) = with_mix(byond_air, |air| {
+	) = with_mix(&byond_air, |air| {
 		Ok((
 			air.thermal_energy(),
 			air.get_moles(plas),
@@ -277,7 +277,7 @@ fn fusion(byond_air: Value, holder: Value) {
 	let standard_waste_gas_output =
 		scale_factor * (FUSION_TRITIUM_CONVERSION_COEFFICIENT * FUSION_TRITIUM_MOLES_USED);
 
-	let standard_energy = with_mix_mut(byond_air, |air| {
+	let standard_energy = with_mix_mut(&byond_air, |air| {
 		air.set_moles(plas, plasma);
 		air.set_moles(co2, carbon);
 
@@ -312,7 +312,7 @@ fn fusion(byond_air: Value, holder: Value) {
 		Proc::find(byond_string!("/proc/fusion_ball"))
 			.unwrap()
 			.call(&[
-				holder,
+				&holder,
 				&Value::from(reaction_energy),
 				&Value::from(standard_energy),
 			])?;
@@ -431,7 +431,7 @@ fn _hook_generic_fire(byond_air: Value, holder: Value) {
 			cached_results.set(byond_string!("fire"), Value::from(fire_amount))?;
 			if temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST {
 				if let Some(fire_expose) = Proc::find(byond_string!("/proc/fire_expose")) {
-					fire_expose.call(&[holder, byond_air, &Value::from(temperature)])?;
+					fire_expose.call(&[&holder, &byond_air, &Value::from(temperature)])?;
 				} else {
 					Proc::find(byond_string!("/proc/stack_trace"))
 						.ok_or_else(|| runtime!("Couldn't find stack_trace!"))?
@@ -442,7 +442,7 @@ fn _hook_generic_fire(byond_air: Value, holder: Value) {
 			}
 			if radiation_released > 0.0 {
 				if let Some(radiation_burn) = Proc::find(byond_string!("/proc/radiation_burn")) {
-					radiation_burn.call(&[holder, &Value::from(radiation_released)])?;
+					radiation_burn.call(&[&holder, &Value::from(radiation_released)])?;
 				} else {
 					let _ = Proc::find(byond_string!("/proc/stack_trace"))
 					.ok_or_else(|| runtime!("Couldn't find stack_trace!"))?


### PR DESCRIPTION
partially based on dmjit's logging, dumps the panic logs to an auxmos.log file and the git hash/branch of the binary. 
each crash from auxmos will make a different log file with a different date on it

also cleans up some warnings and errors detected by rust-analyzer