### PR TITLE
synchronises adjacency updates to post processing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           toolchain: stable
           command: build
-          args: --target i686-pc-windows-msvc --release --features all_reaction_hooks, katmos
+          args: --target i686-pc-windows-msvc --release --features all_reaction_hooks,katmos
         if: matrix.os == 'windows-latest'
 
       - name: Build auxmos (Ubuntu)
@@ -55,7 +55,7 @@ jobs:
         with:
           toolchain: stable
           command: build
-          args: --target i686-unknown-linux-gnu --release --features all_reaction_hooks, katmos
+          args: --target i686-unknown-linux-gnu --release --features all_reaction_hooks,katmos
         if: matrix.os == 'ubuntu-latest'
 
       - name: Upload binary to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Build Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target_name: i686-unknown-linux-gnu
+            artifact_name: libauxmos.so
+          - os: windows-latest
+            target_name: i686-pc-windows-msvc
+            artifact_name: auxmos.dll
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup Toolchains (Windows)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: i686-pc-windows-msvc
+        if: matrix.os == 'windows-latest'
+
+      - name: Install g++ multilib
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install build-essential g++-multilib libc6-i386 libstdc++6:i386
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Setup Toolchains (Ubuntu)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: i686-unknown-linux-gnu
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Build auxmos (Windows)
+        uses: actions-rs/cargo@v1
+        with:
+          toolchain: stable
+          command: build
+          args: --target i686-pc-windows-msvc --release --features all_reaction_hooks, katmos
+        if: matrix.os == 'windows-latest'
+
+      - name: Build auxmos (Ubuntu)
+        uses: actions-rs/cargo@v1
+        with:
+          toolchain: stable
+          command: build
+          args: --target i686-unknown-linux-gnu --release --features all_reaction_hooks, katmos
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Upload binary to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/${{ matrix.target_name }}/release/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.artifact_name }}
+          tag: ${{ github.ref }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "nonmax",
- "parking_lot 0.11.2",
+ "parking_lot",
  "rayon",
  "tinyvec",
 ]
@@ -270,7 +270,7 @@ checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
- "parking_lot 0.12.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -398,15 +398,6 @@ dependencies = [
  "autocfg",
  "hashbrown",
  "rayon",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -561,37 +552,12 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.9",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -678,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ itertools = "0.10.3"
 rayon = "1.5.1"
 float-ord = "0.3.2"
 crossbeam = "0.8.1"
-flume = "0.10.9"
-parking_lot = "0.11.2"
+flume = "0.10.11"
+parking_lot = "0.12.0"
 fxhash = "0.2.1"
 nonmax = "0.5.0"
-indexmap = { version = "1.7.0", features = ["rayon"] }
+indexmap = { version = "1.8.0", features = ["rayon"] }
 ahash = "0.7.6"
 
 [dependencies.dashmap]
-version = "5.0.0"
+version = "5.1.0"
 features = ["raw-api"]
 
 [dependencies.tinyvec]

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -32,9 +32,6 @@ pub fn aux_callbacks_sender(item: usize) -> flume::Sender<DeferredFunc> {
 	unsafe { CALLBACK_CHANNELS.as_ref().unwrap()[item].0.clone() }
 }
 
-pub fn process_turf_adjacencies() {
-	process_aux_callbacks(ADJACENCIES);
-}
 pub fn process_aux_callbacks(item: usize) {
 	let stack_trace = Proc::find("/proc/auxtools_stack_trace").unwrap();
 	with_aux_callback_receiver(

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1,0 +1,50 @@
+use auxtools::*;
+
+type DeferredFunc = Box<dyn Fn() -> DMResult + Send + Sync>;
+
+type CallbackChannel = (flume::Sender<DeferredFunc>, flume::Receiver<DeferredFunc>);
+
+static mut CALLBACK_CHANNELS: Option<[CallbackChannel; 2]> = None;
+
+pub(crate) const ADJACENCIES: usize = 0;
+
+#[init(partial)]
+fn _start_aux_callbacks() -> Result<(), String> {
+	unsafe {
+		CALLBACK_CHANNELS = Some([flume::unbounded(), flume::unbounded()]);
+	}
+	Ok(())
+}
+
+#[shutdown]
+fn _clean_aux_callbacks() {
+	unsafe { CALLBACK_CHANNELS = None }
+}
+
+fn with_aux_callback_receiver<T>(
+	f: impl Fn(&flume::Receiver<DeferredFunc>) -> T,
+	item: usize,
+) -> T {
+	f(unsafe { &CALLBACK_CHANNELS.as_ref().unwrap()[item].1 })
+}
+
+pub fn aux_callbacks_sender(item: usize) -> flume::Sender<DeferredFunc> {
+	unsafe { CALLBACK_CHANNELS.as_ref().unwrap()[item].0.clone() }
+}
+
+pub fn process_turf_adjacencies() {
+	process_aux_callbacks(ADJACENCIES);
+}
+pub fn process_aux_callbacks(item: usize) {
+	let stack_trace = Proc::find("/proc/auxtools_stack_trace").unwrap();
+	with_aux_callback_receiver(
+		|receiver| {
+			for callback in receiver.try_iter() {
+				if let Err(e) = callback() {
+					let _ = stack_trace.call(&[&Value::from_string(e.message.as_str()).unwrap()]);
+				}
+			}
+		},
+		item,
+	)
+}

--- a/src/gas/types.rs
+++ b/src/gas/types.rs
@@ -243,7 +243,7 @@ fn _destroy_gas_info_structs() {
 #[hook("/proc/_auxtools_register_gas")]
 fn _hook_register_gas(gas: Value) {
 	let gas_id = gas.get_string(byond_string!("id"))?;
-	let gas_cache = GasType::new(gas, TOTAL_NUM_GASES.load(Ordering::Relaxed))?;
+	let gas_cache = GasType::new(&gas, TOTAL_NUM_GASES.load(Ordering::Relaxed))?;
 	unsafe { GAS_INFO_BY_STRING.as_ref() }
 		.unwrap()
 		.insert(gas_id.into_boxed_str(), gas_cache.clone());

--- a/src/gas/types.rs
+++ b/src/gas/types.rs
@@ -269,7 +269,7 @@ fn _hook_init() {
 			&mut vec![data.get(data.get(i)?)?],
 		)?;
 	}
-	REACTION_INFO.write().insert(get_reaction_info());
+	let _ = REACTION_INFO.write().insert(get_reaction_info());
 	Ok(Value::from(true))
 }
 
@@ -289,7 +289,7 @@ fn get_reaction_info() -> Vec<Reaction> {
 
 #[hook("/datum/controller/subsystem/air/proc/auxtools_update_reactions")]
 fn _update_reactions() {
-	REACTION_INFO.write().insert(get_reaction_info());
+	let _ = REACTION_INFO.write().insert(get_reaction_info());
 	Ok(Value::from(true))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod turfs;
 
 pub mod reaction;
 
+pub mod callbacks;
+
 use auxtools::*;
 
 use auxcleanup::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ fn _set_moles_hook() {
 fn _adjust_moles_hook(id_val: Value, num_val: Value) {
 	let vf = num_val.as_number().unwrap_or_default();
 	with_mix_mut(src, |mix| {
-		mix.adjust_moles(gas_idx_from_value(id_val)?, vf);
+		mix.adjust_moles(gas_idx_from_value(&id_val)?, vf);
 		Ok(Value::null())
 	})
 }
@@ -284,7 +284,7 @@ fn _scrub_into_hook(into: Value, ratio_v: Value, gas_list: Value) {
 	let gas_scrub_vec = (1..=gases_to_scrub.len())
 		.filter_map(|idx| gas_idx_from_value(&gases_to_scrub.get(idx).unwrap()).ok())
 		.collect::<Vec<_>>();
-	with_mixes_mut(src, into, |src_gas, dest_gas| {
+	with_mixes_mut(src, &into, |src_gas, dest_gas| {
 		src_gas.transfer_gases_to(ratio, &gas_scrub_vec, dest_gas);
 		Ok(Value::from(true))
 	})
@@ -337,7 +337,7 @@ fn _react_hook(holder: Value) {
 	let mut ret: i32 = 0;
 	let reactions = with_mix(src, |mix| Ok(mix.all_reactable()))?;
 	for reaction in reactions {
-		ret |= react_by_id(reaction, src, holder)?
+		ret |= react_by_id(reaction, src, &holder)?
 			.as_number()
 			.unwrap_or_default() as i32;
 		if ret & STOP_REACTIONS == STOP_REACTIONS {
@@ -369,7 +369,7 @@ fn _adjust_heat_hook() {
 
 #[hook("/datum/gas_mixture/proc/transfer_to")]
 fn _transfer_hook(other: Value, moles: Value) {
-	with_mixes_mut(src, other, |our_mix, other_mix| {
+	with_mixes_mut(src, &other, |our_mix, other_mix| {
 		other_mix.merge(&our_mix.remove(moles.as_number().map_err(|_| {
 			runtime!(
 				"Attempt to interpret non-number value as number {} {}:{}",
@@ -384,7 +384,7 @@ fn _transfer_hook(other: Value, moles: Value) {
 
 #[hook("/datum/gas_mixture/proc/transfer_ratio_to")]
 fn _transfer_ratio_hook(other: Value, ratio: Value) {
-	with_mixes_mut(src, other, |our_mix, other_mix| {
+	with_mixes_mut(src, &other, |our_mix, other_mix| {
 		other_mix.merge(&our_mix.remove_ratio(ratio.as_number().map_err(|_| {
 			runtime!(
 				"Attempt to interpret non-number value as number {} {}:{}",

--- a/src/reaction/hooks.rs
+++ b/src/reaction/hooks.rs
@@ -203,7 +203,7 @@ fn fusion(byond_air: Value, holder: Value) {
 		scale_factor,
 		temperature_scale,
 		gas_power,
-	) = with_mix(byond_air, |air| {
+	) = with_mix(&byond_air, |air| {
 		Ok((
 			air.thermal_energy(),
 			air.get_moles(plas),
@@ -277,7 +277,7 @@ fn fusion(byond_air: Value, holder: Value) {
 	let standard_waste_gas_output =
 		scale_factor * (FUSION_TRITIUM_CONVERSION_COEFFICIENT * FUSION_TRITIUM_MOLES_USED);
 
-	let standard_energy = with_mix_mut(byond_air, |air| {
+	let standard_energy = with_mix_mut(&byond_air, |air| {
 		air.set_moles(plas, plasma);
 		air.set_moles(co2, carbon);
 
@@ -312,7 +312,7 @@ fn fusion(byond_air: Value, holder: Value) {
 		Proc::find(byond_string!("/proc/fusion_ball"))
 			.unwrap()
 			.call(&[
-				holder,
+				&holder,
 				&Value::from(reaction_energy),
 				&Value::from(standard_energy),
 			])?;
@@ -431,7 +431,7 @@ fn _hook_generic_fire(byond_air: Value, holder: Value) {
 			cached_results.set(byond_string!("fire"), Value::from(fire_amount))?;
 			if temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST {
 				if let Some(fire_expose) = Proc::find(byond_string!("/proc/fire_expose")) {
-					fire_expose.call(&[holder, byond_air, &Value::from(temperature)])?;
+					fire_expose.call(&[&holder, &byond_air, &Value::from(temperature)])?;
 				} else {
 					Proc::find(byond_string!("/proc/stack_trace"))
 						.ok_or_else(|| runtime!("Couldn't find stack_trace!"))?
@@ -442,7 +442,7 @@ fn _hook_generic_fire(byond_air: Value, holder: Value) {
 			}
 			if radiation_released > 0.0 {
 				if let Some(radiation_burn) = Proc::find(byond_string!("/proc/radiation_burn")) {
-					radiation_burn.call(&[holder, &Value::from(radiation_released)])?;
+					radiation_burn.call(&[&holder, &Value::from(radiation_released)])?;
 				} else {
 					let _ = Proc::find(byond_string!("/proc/stack_trace"))
 					.ok_or_else(|| runtime!("Couldn't find stack_trace!"))?

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -25,7 +25,7 @@ use rayon;
 
 use rayon::prelude::*;
 
-use crate::callbacks::{aux_callbacks_sender, ADJACENCIES};
+use crate::callbacks::aux_callbacks_sender;
 
 const NORTH: u8 = 1;
 const SOUTH: u8 = 2;
@@ -320,7 +320,7 @@ fn _hook_sleep() {
 	} else {
 		0.0
 	};
-	let sender = aux_callbacks_sender(ADJACENCIES);
+	let sender = aux_callbacks_sender(crate::callbacks::ADJACENCIES);
 	let src_id = unsafe { src.raw.data.id };
 	if arg == 0.0 {
 		let _ = sender.send(Box::new(move || {
@@ -344,7 +344,7 @@ fn _hook_infos(arg0: Value, arg1: Value) {
 	let update_now = arg1.as_number().unwrap_or(0.0) != 0.0;
 	let adjacent_to_spess = arg0.as_number().unwrap_or(0.0) != 0.0;
 	let id = unsafe { src.raw.data.id };
-	let sender = aux_callbacks_sender(ADJACENCIES);
+	let sender = aux_callbacks_sender(crate::callbacks::ADJACENCIES);
 	let boxed_fn: Box<dyn Fn() -> DMResult + Send + Sync> = Box::new(move || {
 		let src_turf = unsafe { Value::turf_by_id_unchecked(id) };
 		if let Ok(adjacent_list) = src_turf.get_list(byond_string!("atmos_adjacent_turfs")) {

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -15,7 +15,7 @@ use indexmap::{IndexMap, IndexSet};
 use ahash::RandomState;
 use fxhash::FxBuildHasher;
 
-use crate::callbacks::{process_aux_callbacks, ADJACENCIES};
+use crate::callbacks::process_aux_callbacks;
 
 use auxcallback::byond_callback_sender;
 
@@ -494,7 +494,7 @@ fn explosively_depressurize(
 		}
 	}
 
-	process_aux_callbacks(ADJACENCIES);
+	process_aux_callbacks(crate::callbacks::ADJACENCIES);
 
 	if space_turfs.is_empty() {
 		return Ok(Value::null());

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -15,6 +15,8 @@ use indexmap::{IndexMap, IndexSet};
 use ahash::RandomState;
 use fxhash::FxBuildHasher;
 
+use crate::callbacks::{process_aux_callbacks, ADJACENCIES};
+
 use auxcallback::byond_callback_sender;
 
 use dashmap::*;
@@ -491,6 +493,9 @@ fn explosively_depressurize(
 			return Ok(Value::null()); // planet atmos > space
 		}
 	}
+
+	process_aux_callbacks(ADJACENCIES);
+
 	if space_turfs.is_empty() {
 		return Ok(Value::null());
 	}

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 
 use parking_lot::RwLock;
 
-use crate::callbacks::{process_aux_callbacks, ADJACENCIES};
+use crate::callbacks::process_aux_callbacks;
 
 const PROCESS_NOT_STARTED: u8 = 0;
 
@@ -57,7 +57,7 @@ fn _finish_process_turfs() {
 		Ordering::Relaxed,
 	) == Err(PROCESS_PROCESSING);
 	if !processing_turfs_unfinished {
-		process_aux_callbacks(ADJACENCIES);
+		process_aux_callbacks(crate::callbacks::ADJACENCIES);
 	}
 	if processing_callbacks_unfinished || processing_turfs_unfinished {
 		Ok(Value::from(true))

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -14,13 +14,15 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 
 use parking_lot::RwLock;
 
+use crate::callbacks::{process_aux_callbacks, ADJACENCIES};
+
 const PROCESS_NOT_STARTED: u8 = 0;
 
 const PROCESS_PROCESSING: u8 = 1;
 
 const PROCESS_DONE: u8 = 2;
 
-static PROCESSING_TURF_STEP: AtomicU8 = AtomicU8::new(PROCESS_NOT_STARTED);
+pub(crate) static PROCESSING_TURF_STEP: AtomicU8 = AtomicU8::new(PROCESS_NOT_STARTED);
 
 static WAITING_FOR_THREAD: AtomicBool = AtomicBool::new(false);
 
@@ -54,6 +56,9 @@ fn _finish_process_turfs() {
 		Ordering::SeqCst,
 		Ordering::Relaxed,
 	) == Err(PROCESS_PROCESSING);
+	if !processing_turfs_unfinished {
+		process_aux_callbacks(ADJACENCIES);
+	}
 	if processing_callbacks_unfinished || processing_turfs_unfinished {
 		Ok(Value::from(true))
 	} else {

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -22,7 +22,7 @@ const PROCESS_PROCESSING: u8 = 1;
 
 const PROCESS_DONE: u8 = 2;
 
-pub(crate) static PROCESSING_TURF_STEP: AtomicU8 = AtomicU8::new(PROCESS_NOT_STARTED);
+static PROCESSING_TURF_STEP: AtomicU8 = AtomicU8::new(PROCESS_NOT_STARTED);
 
 static WAITING_FOR_THREAD: AtomicBool = AtomicBool::new(false);
 


### PR DESCRIPTION
adjacency updates are no longer handled by ssadjacent_air since it can still race with katmos on.
it's now moved into a separate unlimited callback channel to be called on post processing

also I wrote a release script that autobuilds a binary and upload it to new releases 