### PR TITLE
More deferring; more often running callbacks

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -6,7 +6,9 @@ type CallbackChannel = (flume::Sender<DeferredFunc>, flume::Receiver<DeferredFun
 
 static mut CALLBACK_CHANNELS: Option<[CallbackChannel; 2]> = None;
 
-pub(crate) const ADJACENCIES: usize = 0;
+pub(crate) const TURFS: usize = 0;
+
+pub(crate) const TEMPERATURE: usize = 1;
 
 #[init(partial)]
 fn _start_aux_callbacks() -> Result<(), String> {

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -497,7 +497,7 @@ fn explosively_depressurize(
 		}
 	}
 
-	process_aux_callbacks(crate::callbacks::ADJACENCIES);
+	process_aux_callbacks(crate::callbacks::TURFS);
 
 	if space_turfs.is_empty() {
 		return Ok(Value::null());


### PR DESCRIPTION
Adds a second callback channel for turf temperature updates, called before the temperature process runs;

Makes adding/removing turfs from the turf list happen in a callback;

Renames ADJACENCY callback channel to TURFS callback channel;

Makes the TURFS callback channel run through right as turf processing starts, just before the thread is called (since it's technically possible that byond does stuff between).