### PR TITLE
Near-instantaneous vis updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ fn _get_gases_hook() {
 		let gases_list: List = List::new();
 		mix.for_each_gas(|idx, gas| {
 			if gas > GAS_MIN_MOLES {
-				gases_list.append(Value::from_string(&*gas_idx_to_id(idx)?)?);
+				gases_list.append(gas_idx_to_id(idx)?);
 			}
 			Ok(())
 		})?;

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -132,10 +132,7 @@ impl Reaction {
 				let mut min_gas_reqs: Vec<(GasIDX, f32)> = Vec::new();
 				for i in 0..total_num_gases() {
 					if let Ok(req_amount) = min_reqs
-						.get(
-							Value::from_string(&*gas_idx_to_id(i).unwrap())
-								.unwrap_or_else(|_| Value::null()),
-						)
+						.get(gas_idx_to_id(i).unwrap_or_else(|_| Value::null()))
 						.and_then(|v| v.as_number())
 					{
 						min_gas_reqs.push((i, req_amount));

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -718,7 +718,8 @@ fn post_process() {
 					}
 				}
 				if should_update_vis {
-					turf.call("update_visuals", &[])?;
+					//turf.call("update_visuals", &[])?;
+					update_visuals(turf)?;
 				}
 			}
 			Ok(Value::null())


### PR DESCRIPTION
turns out the rwlock was what's making vis updates 1000x slower, this fixes that by not using turf_gases() and caching the string in a hashmap instead