### PR TITLE
Graph-based adjacency refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "auxtools"
 version = "0.1.0"
-source = "git+https://github.com/willox/auxtools#07523bf823ff632a97f16a911de34547e839a000"
+source = "git+https://github.com/willox/auxtools#9204e120e2440578259a610ba6aedfa1529463c6"
 dependencies = [
  "ahash",
  "auxtools-impl",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "auxtools-impl"
 version = "0.1.0"
-source = "git+https://github.com/willox/auxtools#07523bf823ff632a97f16a911de34547e839a000"
+source = "git+https://github.com/willox/auxtools#9204e120e2440578259a610ba6aedfa1529463c6"
 dependencies = [
  "hex",
  "proc-macro2",
@@ -118,9 +118,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -227,13 +227,14 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391b56fbd302e585b7a9494fb70e40949567b1cf9003a8e4a6041a1687c26573"
+checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown 0.12.1",
  "lock_api",
+ "parking_lot_core",
  "rayon",
 ]
 
@@ -393,9 +394,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
@@ -549,15 +550,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -698,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "lazy_static",
  "nonmax",
  "parking_lot",
+ "petgraph",
  "rayon",
  "tinyvec",
 ]
@@ -275,6 +276,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
 name = "float-ord"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,9 +460,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libudis86-sys"
@@ -542,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
 
 [[package]]
 name = "parking_lot"
@@ -570,6 +577,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "git+https://github.com/jupyterkat/petgraph#8eb797f38c620bbaa616f5a1b7322f4f5dbe599d"
+dependencies = [
+ "fixedbitset",
+ "fxhash",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,11 +608,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -609,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -621,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -681,13 +698,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -712,10 +729,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.3"
+name = "unicode-ident"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ lazy_static = "1.4.0"
 indexmap = { version = "1.8.0", features = ["rayon"] }
 dashmap = { version = "5.2.0", features = ["rayon"] }
 atomic_float = "0.1.0"
+petgraph = { git = "https://github.com/jupyterkat/petgraph"}
 
 [dependencies.tinyvec]
 version = "1.5.1"

--- a/src/gas/types.rs
+++ b/src/gas/types.rs
@@ -201,7 +201,7 @@ impl GasType {
 								})
 								.collect(),
 						))
-					} else if let Ok(_) = product_info.as_number() {
+					} else if product_info.as_number().is_ok() {
 						Some(FireProductInfo::Plasma) // if we add another snowflake later, add it, but for now we hack this in
 					} else {
 						None

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -160,11 +160,16 @@ struct ThermalInfo {
 	pub adjacency: u8,
 	pub adjacent_to_space: bool,
 }
+
+//adjacency/turf infos goes here
+//It's a stable graph because we want to be able to remove turfs
+//without screwing with other turf's ids
 struct TurfGases {
 	graph: StableDiGraph<TurfMixture, ()>,
 	map: HashMap<TurfID, NodeIndex, FxBuildHasher>,
 }
 
+#[allow(unused)]
 impl TurfGases {
 	pub fn remove_turf(&mut self, idx: TurfID) {
 		if let Some(tmix) = self.map.remove(&idx) {
@@ -207,6 +212,7 @@ impl TurfGases {
 	}
 
 	//This isn't a useless collect(), we can't hold a mutable ref and an immutable ref at once on the graph
+	#[allow(clippy::needless_collect)]
 	pub fn remove_adjacencies(&mut self, idx: TurfID) {
 		if let Some(index) = self.map.get(&idx) {
 			let edges = self

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -226,6 +226,10 @@ impl TurfGases {
 			.and_then(|index| self.graph.node_weight(*index))
 	}
 
+	pub fn get_nodeid(&self, idx: &TurfID) -> Option<NodeIndex> {
+		self.map.get(idx).copied()
+	}
+
 	pub fn get(&self, idx: NodeIndex) -> Option<&TurfMixture> {
 		self.graph.node_weight(idx)
 	}
@@ -235,6 +239,12 @@ impl TurfGases {
 		index: NodeIndex,
 	) -> impl Iterator<Item = NodeIndex> + '_ {
 		self.graph.neighbors(index)
+	}
+
+	pub fn adjacent_turf_ids<'a>(&'a self, index: NodeIndex) -> impl Iterator<Item = TurfID> + '_ {
+		self.graph
+			.neighbors(index)
+			.filter_map(|index| Some(self.get(index)?.id))
 	}
 
 	pub fn adjacent_node_ids_enabled<'a>(
@@ -404,9 +414,12 @@ const OPEN_TURF: i32 = 2;
 
 //hardcoded because we can't have nice things
 fn determine_turf_flag(src: &Value) -> i32 {
-	let path = src.get_type().unwrap_or("TYPENOTFOUND".to_string());
+	let path = src.get_type().unwrap_or_else(|_| "TYPPENOTFOUND".to_string());
 	let is_open = path.as_str().starts_with("/turf/open");
-	let is_planet = src.get_number(byond_string!("planetary_atmos")).unwrap_or(0.0) > 0.0;
+	let is_planet = src
+		.get_number(byond_string!("planetary_atmos"))
+		.unwrap_or(0.0)
+		> 0.0;
 	let is_space = path.as_str().starts_with("/turf/open/space");
 
 	let mut flag: i32 = CLOSED_TURF;

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -77,6 +77,12 @@ impl TurfMixture {
 		let simul_flags = self.flags & SIMULATION_FLAGS;
 		simul_flags & SIMULATION_DISABLED == 0 && simul_flags & SIMULATION_ANY != 0
 	}
+
+	pub fn is_sleeping(&self) -> bool {
+		let simul_flags = self.flags & SIMULATION_FLAGS;
+		simul_flags & SIMULATION_DISABLED != 0
+	}
+
 	pub fn is_immutable(&self) -> bool {
 		GasArena::with_all_mixtures(|all_mixtures| {
 			all_mixtures
@@ -514,6 +520,7 @@ fn _hook_turf_update_temp() {
 	}
 	Ok(Value::null())
 }
+
 /* will deadlock, don't recommend using this
 #[hook("/turf/proc/set_sleeping")]
 fn _hook_sleep() {

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -414,7 +414,9 @@ const OPEN_TURF: i32 = 2;
 
 //hardcoded because we can't have nice things
 fn determine_turf_flag(src: &Value) -> i32 {
-	let path = src.get_type().unwrap_or_else(|_| "TYPPENOTFOUND".to_string());
+	let path = src
+		.get_type()
+		.unwrap_or_else(|_| "TYPPENOTFOUND".to_string());
 	let is_open = path.as_str().starts_with("/turf/open");
 	let is_planet = src
 		.get_number(byond_string!("planetary_atmos"))

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -165,8 +165,8 @@ struct ThermalInfo {
 //It's a stable graph because we want to be able to remove turfs
 //without screwing with other turf's ids
 struct TurfGases {
-	graph: StableDiGraph<TurfMixture, ()>,
-	map: HashMap<TurfID, NodeIndex, FxBuildHasher>,
+	graph: StableDiGraph<TurfMixture, (), usize>,
+	map: HashMap<TurfID, NodeIndex<usize>, FxBuildHasher>,
 }
 
 #[allow(unused)]
@@ -232,22 +232,25 @@ impl TurfGases {
 			.and_then(|index| self.graph.node_weight(*index))
 	}
 
-	pub fn get_nodeid(&self, idx: &TurfID) -> Option<NodeIndex> {
+	pub fn get_nodeid(&self, idx: &TurfID) -> Option<NodeIndex<usize>> {
 		self.map.get(idx).copied()
 	}
 
-	pub fn get(&self, idx: NodeIndex) -> Option<&TurfMixture> {
+	pub fn get(&self, idx: NodeIndex<usize>) -> Option<&TurfMixture> {
 		self.graph.node_weight(idx)
 	}
 
 	pub fn adjacent_node_ids<'a>(
 		&'a self,
-		index: NodeIndex,
-	) -> impl Iterator<Item = NodeIndex> + '_ {
+		index: NodeIndex<usize>,
+	) -> impl Iterator<Item = NodeIndex<usize>> + '_ {
 		self.graph.neighbors(index)
 	}
 
-	pub fn adjacent_turf_ids<'a>(&'a self, index: NodeIndex) -> impl Iterator<Item = TurfID> + '_ {
+	pub fn adjacent_turf_ids<'a>(
+		&'a self,
+		index: NodeIndex<usize>,
+	) -> impl Iterator<Item = TurfID> + '_ {
 		self.graph
 			.neighbors(index)
 			.filter_map(|index| Some(self.get(index)?.id))
@@ -255,8 +258,8 @@ impl TurfGases {
 
 	pub fn adjacent_node_ids_enabled<'a>(
 		&'a self,
-		index: NodeIndex,
-	) -> impl Iterator<Item = NodeIndex> + '_ {
+		index: NodeIndex<usize>,
+	) -> impl Iterator<Item = NodeIndex<usize>> + '_ {
 		self.graph.neighbors(index).filter(|&adj_index| {
 			self.graph
 				.node_weight(adj_index)
@@ -266,7 +269,7 @@ impl TurfGases {
 
 	pub fn adjacent_mixes<'a>(
 		&'a self,
-		index: NodeIndex,
+		index: NodeIndex<usize>,
 		all_mixtures: &'a [parking_lot::RwLock<Mixture>],
 	) -> impl Iterator<Item = &'a parking_lot::RwLock<Mixture>> {
 		self.graph
@@ -277,7 +280,7 @@ impl TurfGases {
 
 	pub fn adjacent_mixes_with_adj_ids<'a>(
 		&'a self,
-		index: NodeIndex,
+		index: NodeIndex<usize>,
 		all_mixtures: &'a [parking_lot::RwLock<Mixture>],
 	) -> impl Iterator<Item = (&'a TurfID, &'a parking_lot::RwLock<Mixture>)> {
 		self.graph
@@ -286,7 +289,7 @@ impl TurfGases {
 			.filter_map(move |idx| Some((&idx.id, all_mixtures.get(idx.mix)?)))
 	}
 
-	pub fn adjacent_infos(&self, index: NodeIndex) -> impl Iterator<Item = &TurfMixture> {
+	pub fn adjacent_infos(&self, index: NodeIndex<usize>) -> impl Iterator<Item = &TurfMixture> {
 		self.graph
 			.neighbors(index)
 			.filter_map(|neighbor| self.graph.node_weight(neighbor))

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -510,7 +510,15 @@ fn explosively_depressurize(initial_index: NodeIndex, equalize_hard_turf_limit: 
 				)
 			})?;
 
-		let get_dir = Proc::find(byond_string!("/proc/get_dir_multiz")).unwrap();
+		let get_dir = Proc::find(byond_string!("/proc/get_dir_multiz")).map_or(
+			Err(runtime!(
+				"Proc get_dir_multiz not found! {} {}:{}",
+				std::file!(),
+				std::line!(),
+				std::column!()
+			)),
+			|opt| Ok(opt),
+		)?;
 
 		for (cur_index, cur_mixture) in progression_order.iter().rev() {
 			let cur_orig = info.entry(*cur_index).or_default();

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -417,8 +417,7 @@ fn explosively_depressurize(initial_index: TurfID, equalize_hard_turf_limit: usi
 					if cur_queue_idx > equalize_hard_turf_limit {
 						continue;
 					}
-					for adj_index in arena
-						.adjacent_turf_ids(arena.get_nodeid(&cur_index).unwrap())
+					for adj_index in arena.adjacent_turf_ids(arena.get_nodeid(&cur_index).unwrap())
 					{
 						if turfs.insert(adj_index) {
 							unsafe { Value::turf_by_id_unchecked(cur_index) }.call(

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -5,7 +5,7 @@ use super::*;
 use std::{
 	cell::Cell,
 	{
-		collections::{BTreeSet, HashMap, HashSet},
+		collections::{HashMap, HashSet},
 		sync::atomic::AtomicUsize,
 	},
 };
@@ -19,30 +19,28 @@ use crate::callbacks::process_aux_callbacks;
 
 use auxcallback::byond_callback_sender;
 
-use dashmap::DashMap;
+use parking_lot::RwLockReadGuard;
 
-type TransferInfo = [f32; 7];
+type MixWithID = (NodeIndex, TurfMixture);
 
-type MixWithID = (TurfID, TurfMixture);
+type RefMixWithID<'a> = (&'a NodeIndex, &'a TurfMixture);
 
-type RefMixWithID<'a> = (&'a TurfID, &'a TurfMixture);
+use petgraph::{graph::NodeIndex, graphmap::DiGraphMap};
 
 #[derive(Copy, Clone)]
 struct MonstermosInfo {
-	transfer_dirs: TransferInfo,
 	mole_delta: f32,
 	curr_transfer_amount: f32,
-	curr_transfer_dir: usize,
+	curr_transfer_dir: Option<NodeIndex>,
 	fast_done: bool,
 }
 
 impl Default for MonstermosInfo {
 	fn default() -> MonstermosInfo {
 		MonstermosInfo {
-			transfer_dirs: [0_f32; 7],
 			mole_delta: 0_f32,
 			curr_transfer_amount: 0_f32,
-			curr_transfer_dir: 6,
+			curr_transfer_dir: None,
 			fast_done: false,
 		}
 	}
@@ -51,619 +49,583 @@ impl Default for MonstermosInfo {
 #[derive(Copy, Clone)]
 struct ReducedInfo {
 	curr_transfer_amount: f32,
-	curr_transfer_dir: usize,
+	curr_transfer_dir: Option<NodeIndex>,
 }
 
 impl Default for ReducedInfo {
 	fn default() -> ReducedInfo {
 		ReducedInfo {
 			curr_transfer_amount: 0_f32,
-			curr_transfer_dir: 6,
+			curr_transfer_dir: None,
 		}
 	}
 }
 
-const OPP_DIR_INDEX: [usize; 7] = [1, 0, 3, 2, 5, 4, 6];
-
-impl MonstermosInfo {
-	fn adjust_eq_movement(&mut self, adjacent: Option<&mut Self>, dir_index: usize, amount: f32) {
-		self.transfer_dirs[dir_index] += amount;
-		if let Some(adj) = adjacent {
-			if dir_index != 6 {
-				adj.transfer_dirs[OPP_DIR_INDEX[dir_index]] -= amount;
-			}
+fn adjust_eq_movement(
+	this_turf: Option<NodeIndex>,
+	that_turf: Option<NodeIndex>,
+	amount: f32,
+	graph: &mut DiGraphMap<Option<NodeIndex>, f32>,
+) {
+	if graph.contains_edge(this_turf, that_turf) {
+		*graph.edge_weight_mut(this_turf, that_turf).unwrap() += amount;
+	} else {
+		graph.add_edge(this_turf, that_turf, amount);
+	}
+	if that_turf.is_some() {
+		if graph.contains_edge(that_turf, this_turf) {
+			*graph.edge_weight_mut(that_turf, this_turf).unwrap() -= amount;
+		} else {
+			graph.add_edge(that_turf, this_turf, -amount);
 		}
-	}
-}
-
-//so basically the old method of getting adjacent tiles includes the orig tile itself, don't want that here
-#[derive(Clone, Copy)]
-struct AdjacentTileIDsNoorig {
-	adj: u8,
-	i: TurfID,
-	max_x: i32,
-	max_y: i32,
-	count: u8,
-}
-
-impl Iterator for AdjacentTileIDsNoorig {
-	type Item = (u8, TurfID);
-
-	fn next(&mut self) -> Option<Self::Item> {
-		loop {
-			if self.count > 5 {
-				return None;
-			}
-			self.count += 1;
-			let bit = 1 << (self.count - 1);
-			if self.adj & bit == bit {
-				return Some((
-					self.count - 1,
-					adjacent_tile_id(self.count - 1, self.i, self.max_x, self.max_y),
-				));
-			}
-		}
-	}
-
-	fn size_hint(&self) -> (usize, Option<usize>) {
-		(0, Some(self.adj.count_ones() as usize))
-	}
-}
-
-impl FusedIterator for AdjacentTileIDsNoorig {}
-
-fn adjacent_tile_ids_no_orig(adj: u8, i: TurfID, max_x: i32, max_y: i32) -> AdjacentTileIDsNoorig {
-	AdjacentTileIDsNoorig {
-		adj,
-		i,
-		max_x,
-		max_y,
-		count: 0,
 	}
 }
 
 fn finalize_eq(
-	i: TurfID,
+	index: NodeIndex,
 	turf: &TurfMixture,
-	turfs: &IndexMap<TurfID, TurfMixture, FxBuildHasher>,
-	max_x: i32,
-	max_y: i32,
-	info: &DashMap<TurfID, MonstermosInfo, FxBuildHasher>,
+	arena: &RwLockReadGuard<TurfGases>,
+	info: &HashMap<NodeIndex, MonstermosInfo, FxBuildHasher>,
+	eq_movement_graph: &mut DiGraphMap<Option<NodeIndex>, f32>,
 ) {
 	let sender = byond_callback_sender();
 	let transfer_dirs = {
-		let maybe_monstermos_orig = info.get_mut(&i);
-		if maybe_monstermos_orig.is_none() {
+		let pairs = eq_movement_graph
+			.edges(Some(index))
+			.map(|(_, opt2, amt)| (opt2, *amt))
+			.collect::<HashMap<_, _, FxBuildHasher>>();
+
+		if pairs.is_empty() {
 			return;
 		}
-		let mut monstermos_orig = maybe_monstermos_orig.unwrap();
-		let transfer_dirs = monstermos_orig.transfer_dirs;
-		monstermos_orig
-			.transfer_dirs
-			.iter_mut()
-			.for_each(|a| *a = 0.0); // null it out to prevent infinite recursion.
-		transfer_dirs
+		// null it out to prevent infinite recursion.
+		pairs.iter().for_each(|(that_node, _)| {
+			eq_movement_graph.remove_edge(Some(index), *that_node);
+		});
+		pairs
 	};
-	let planet_transfer_amount = transfer_dirs[6];
-	if planet_transfer_amount > 0.0 {
-		if turf.total_moles() < planet_transfer_amount {
-			finalize_eq_neighbors(i, turf, turfs, transfer_dirs, max_x, max_y, info);
-		}
-		drop(GasArena::with_gas_mixture_mut(turf.mix, |gas| {
-			gas.add(-planet_transfer_amount);
-			Ok(())
-		}));
-	} else if planet_transfer_amount < 0.0 {
-		if let Some(air_entry) = turf
-			.planetary_atmos
-			.and_then(|i| planetary_atmos().try_get(&i).try_unwrap())
-		{
-			let planet_air = air_entry.value();
-			let planet_sum = planet_air.total_moles();
-			if planet_sum > 0.0 {
-				drop(GasArena::with_gas_mixture_mut(turf.mix, |gas| {
-					gas.merge(&(planet_air * (-planet_transfer_amount / planet_sum)));
-					Ok(())
-				}));
+	if let Some(&planet_transfer_amount) = transfer_dirs.get(&None) {
+		if planet_transfer_amount > 0.0 {
+			if turf.total_moles() < planet_transfer_amount {
+				finalize_eq_neighbors(index, arena, &transfer_dirs, info, eq_movement_graph);
+			}
+			drop(GasArena::with_gas_mixture_mut(turf.mix, |gas| {
+				gas.add(-planet_transfer_amount);
+				Ok(())
+			}));
+		} else if planet_transfer_amount < 0.0 {
+			if let Some(air_entry) = turf
+				.planetary_atmos
+				.and_then(|i| planetary_atmos().try_get(&i).try_unwrap())
+			{
+				let planet_air = air_entry.value();
+				let planet_sum = planet_air.total_moles();
+				if planet_sum > 0.0 {
+					drop(GasArena::with_gas_mixture_mut(turf.mix, |gas| {
+						gas.merge(&(planet_air * (-planet_transfer_amount / planet_sum)));
+						Ok(())
+					}));
+				}
 			}
 		}
 	}
-	for (j, adj_id) in adjacent_tile_ids_no_orig(turf.adjacency, i, max_x, max_y) {
-		let amount = transfer_dirs[j as usize];
+	let cur_turf_id = arena.get(index).unwrap().id;
+	for adj_index in arena.adjacent_node_ids(index) {
+		let amount = *transfer_dirs.get(&Some(adj_index)).unwrap_or(&0.0);
 		if amount > 0.0 {
 			if turf.total_moles() < amount {
-				finalize_eq_neighbors(i, turf, turfs, transfer_dirs, max_x, max_y, info);
+				finalize_eq_neighbors(index, arena, &transfer_dirs, info, eq_movement_graph);
 			}
-			if let Some(mut adj_info) = info.get_mut(&adj_id) {
-				if let Some(adj_turf) = turfs.get(&adj_id) {
-					adj_info.transfer_dirs[OPP_DIR_INDEX[j as usize]] = 0.0;
-					if turf.mix != adj_turf.mix {
-						drop(GasArena::with_gas_mixtures_mut(
-							turf.mix,
-							adj_turf.mix,
-							|air, other_air| {
-								other_air.merge(&air.remove(amount));
-								Ok(())
-							},
-						));
-					}
-					drop(sender.try_send(Box::new(move || {
-						let real_amount = Value::from(amount);
-						let turf = unsafe { Value::turf_by_id_unchecked(i as u32) };
-						let other_turf = unsafe { Value::turf_by_id_unchecked(adj_id as u32) };
-						if let Err(e) =
-							turf.call("consider_pressure_difference", &[&other_turf, &real_amount])
-						{
-							Proc::find(byond_string!("/proc/stack_trace"))
-								.ok_or_else(|| runtime!("Couldn't find stack_trace!"))?
-								.call(&[&Value::from_string(e.message.as_str())?])?;
-						}
-						Ok(Value::null())
-					})));
+			if let Some(adj_tmix) = arena.get(adj_index) {
+				if let Some(amt) = eq_movement_graph.edge_weight_mut(Some(adj_index), Some(index)) {
+					*amt = 0.0;
 				}
+				if turf.mix != adj_tmix.mix {
+					drop(GasArena::with_gas_mixtures_mut(
+						turf.mix,
+						adj_tmix.mix,
+						|air, other_air| {
+							other_air.merge(&air.remove(amount));
+							Ok(())
+						},
+					));
+				}
+				let adj_turf_id = adj_tmix.id;
+				drop(sender.try_send(Box::new(move || {
+					let real_amount = Value::from(amount);
+					let turf = unsafe { Value::turf_by_id_unchecked(cur_turf_id) };
+					let other_turf = unsafe { Value::turf_by_id_unchecked(adj_turf_id) };
+					if let Err(e) =
+						turf.call("consider_pressure_difference", &[&other_turf, &real_amount])
+					{
+						Proc::find(byond_string!("/proc/stack_trace"))
+							.ok_or_else(|| runtime!("Couldn't find stack_trace!"))?
+							.call(&[&Value::from_string(e.message.as_str())?])?;
+					}
+					Ok(Value::null())
+				})));
 			}
 		}
 	}
 }
 
 fn finalize_eq_neighbors(
-	i: TurfID,
-	turf: &TurfMixture,
-	turfs: &IndexMap<TurfID, TurfMixture, FxBuildHasher>,
-	transfer_dirs: [f32; 7],
-	max_x: i32,
-	max_y: i32,
-	info: &DashMap<TurfID, MonstermosInfo, FxBuildHasher>,
+	index: NodeIndex,
+	arena: &RwLockReadGuard<TurfGases>,
+	transfer_dirs: &HashMap<Option<NodeIndex>, f32, FxBuildHasher>,
+	info: &HashMap<NodeIndex, MonstermosInfo, FxBuildHasher>,
+	eq_movement_graph: &mut DiGraphMap<Option<NodeIndex>, f32>,
 ) {
-	for (j, adjacent_id) in adjacent_tile_ids_no_orig(turf.adjacency, i, max_x, max_y) {
-		let amount = transfer_dirs[j as usize];
+	for adj_index in arena.adjacent_node_ids(index) {
+		let amount = *transfer_dirs.get(&Some(adj_index)).unwrap_or(&0.0);
 		if amount < 0.0 {
 			let other_turf = {
-				let maybe = turfs.get(&adjacent_id);
+				let maybe = arena.get(adj_index);
 				if maybe.is_none() {
 					continue;
 				}
 				maybe.unwrap()
 			};
-			finalize_eq(adjacent_id, other_turf, turfs, max_x, max_y, info);
+			finalize_eq(adj_index, other_turf, arena, info, eq_movement_graph);
 		}
 	}
 }
 
 fn monstermos_fast_process(
-	i: TurfID,
-	m: &TurfMixture,
-	turfs: &IndexMap<TurfID, TurfMixture, FxBuildHasher>,
-	max_x: i32,
-	max_y: i32,
-	info: &DashMap<TurfID, MonstermosInfo, FxBuildHasher>,
+	cur_index: NodeIndex,
+	arena: &RwLockReadGuard<TurfGases>,
+	info: &mut HashMap<NodeIndex, MonstermosInfo, FxBuildHasher>,
+	eq_movement_graph: &mut DiGraphMap<Option<NodeIndex>, f32>,
 ) {
 	let mut cur_info = {
-		let maybe_cur_orig = info.get_mut(&i);
-		if maybe_cur_orig.is_none() {
-			return;
-		}
-		let mut cur_info = maybe_cur_orig.unwrap();
+		let mut cur_info = info.get_mut(&cur_index).unwrap();
 		cur_info.fast_done = true;
 		*cur_info
 	};
-	let mut eligible_adjacents: u8 = 0;
+	let mut eligible_adjacents: Vec<NodeIndex> = Default::default();
 	if cur_info.mole_delta > 0.0 {
-		for (j, loc) in adjacent_tile_ids_no_orig(m.adjacency, i, max_x, max_y) {
-			if turfs.get(&loc).map_or(false, TurfMixture::enabled) {
-				if let Some(adj_info) = info.get(&loc) {
-					if !adj_info.fast_done {
-						eligible_adjacents |= 1 << j;
-					}
+		for adj_turf in arena.adjacent_node_ids_enabled(cur_index) {
+			if let Some(adj_info) = info.get(&adj_turf) {
+				if !adj_info.fast_done {
+					eligible_adjacents.push(adj_turf);
 				}
 			}
 		}
-		let amt_eligible = eligible_adjacents.count_ones();
-		if amt_eligible == 0 {
-			info.entry(i).and_modify(|entry| *entry = cur_info);
+		if eligible_adjacents.is_empty() {
+			info.entry(cur_index).and_modify(|entry| *entry = cur_info);
 			return;
 		}
-		let moles_to_move = cur_info.mole_delta / amt_eligible as f32;
-		for (j, loc) in adjacent_tile_ids_no_orig(eligible_adjacents, i, max_x, max_y) {
-			if let Some(mut adj_info) = info.get_mut(&loc) {
-				cur_info.adjust_eq_movement(Some(&mut adj_info), j as usize, moles_to_move);
+		let moles_to_move = cur_info.mole_delta / eligible_adjacents.len() as f32;
+		eligible_adjacents.into_iter().for_each(|adj_index| {
+			if let Some(mut adj_info) = info.get_mut(&adj_index) {
+				adjust_eq_movement(
+					Some(cur_index),
+					Some(adj_index),
+					moles_to_move,
+					eq_movement_graph,
+				);
 				cur_info.mole_delta -= moles_to_move;
 				adj_info.mole_delta += moles_to_move;
 			}
-			info.entry(i).and_modify(|entry| *entry = cur_info);
-		}
+			info.entry(cur_index).and_modify(|entry| *entry = cur_info);
+		});
 	}
 }
 
 fn give_to_takers(
 	giver_turfs: &[RefMixWithID],
-	_taker_turfs: &[RefMixWithID],
-	turfs: &IndexMap<TurfID, TurfMixture, FxBuildHasher>,
-	max_x: i32,
-	max_y: i32,
-	info: &DashMap<TurfID, MonstermosInfo, FxBuildHasher>,
+	arena: &RwLockReadGuard<TurfGases>,
+	info: &mut HashMap<NodeIndex, MonstermosInfo, FxBuildHasher>,
+	eq_movement_graph: &mut DiGraphMap<Option<NodeIndex>, f32>,
 ) {
-	let mut queue: IndexMap<TurfID, &TurfMixture, FxBuildHasher> =
-		IndexMap::with_hasher(FxBuildHasher::default());
-
-	for &(i, m) in giver_turfs {
+	let mut queue: IndexSet<NodeIndex, FxBuildHasher> = Default::default();
+	for (&index, _) in giver_turfs {
 		let mut giver_info = {
-			let maybe_giver_orig = info.get_mut(i);
-			if maybe_giver_orig.is_none() {
-				continue;
-			}
-			let mut giver_info = maybe_giver_orig.unwrap();
-			giver_info.curr_transfer_dir = 6;
+			let giver_info = info.get_mut(&index).unwrap();
+			giver_info.curr_transfer_dir = None;
 			giver_info.curr_transfer_amount = 0.0;
 			*giver_info
 		};
-		queue.insert(*i, m);
+		queue.insert(index);
 		let mut queue_idx = 0;
-		while let Some((idx, turf)) = queue.get_index(queue_idx) {
+
+		while let Some(&cur_index) = queue.get_index(queue_idx) {
 			if giver_info.mole_delta <= 0.0 {
 				break;
 			}
-			for (j, loc) in adjacent_tile_ids_no_orig(turf.adjacency, *idx, max_x, max_y) {
+			for adj_idx in arena.adjacent_node_ids_enabled(cur_index) {
 				if giver_info.mole_delta <= 0.0 {
 					break;
 				}
-				if let Some(mut adj_info) = info.get_mut(&loc) {
-					if let Some(adj_mix) = turfs
-						.get(&loc)
-						.and_then(|terf| terf.enabled().then(|| terf))
-					{
-						if queue.insert(loc, adj_mix).is_none() {
-							adj_info.curr_transfer_dir = OPP_DIR_INDEX[j as usize];
-							adj_info.curr_transfer_amount = 0.0;
-							if adj_info.mole_delta < 0.0 {
-								// this turf needs gas. Let's give it to 'em.
-								if -adj_info.mole_delta > giver_info.mole_delta {
-									// we don't have enough gas
-									adj_info.curr_transfer_amount -= giver_info.mole_delta;
-									adj_info.mole_delta += giver_info.mole_delta;
-									giver_info.mole_delta = 0.0;
-								} else {
-									// we have enough gas.
-									adj_info.curr_transfer_amount += adj_info.mole_delta;
-									giver_info.mole_delta += adj_info.mole_delta;
-									adj_info.mole_delta = 0.0;
-								}
+				if let Some(mut adj_info) = info.get_mut(&adj_idx) {
+					if queue.insert(adj_idx) {
+						adj_info.curr_transfer_dir = Some(cur_index);
+						adj_info.curr_transfer_amount = 0.0;
+						if adj_info.mole_delta < 0.0 {
+							// this turf needs gas. Let's give it to 'em.
+							if -adj_info.mole_delta > giver_info.mole_delta {
+								// we don't have enough gas
+								adj_info.curr_transfer_amount -= giver_info.mole_delta;
+								adj_info.mole_delta += giver_info.mole_delta;
+								giver_info.mole_delta = 0.0;
+							} else {
+								// we have enough gas.
+								adj_info.curr_transfer_amount += adj_info.mole_delta;
+								giver_info.mole_delta += adj_info.mole_delta;
+								adj_info.mole_delta = 0.0;
 							}
 						}
 					}
 				}
-				info.entry(*i).and_modify(|entry| *entry = giver_info);
+				info.entry(index).and_modify(|entry| *entry = giver_info);
 			}
+
 			queue_idx += 1;
 		}
-		for (idx, _) in queue.drain(..).rev() {
-			if let Some(mut turf_info) = info.get_mut(&idx) {
-				if turf_info.curr_transfer_amount != 0.0 && turf_info.curr_transfer_dir != 6 {
-					if let Some(mut adj_info) = info.get_mut(&adjacent_tile_id(
-						turf_info.curr_transfer_dir as u8,
-						idx,
-						max_x,
-						max_y,
-					)) {
-						let (dir, amt) =
-							(turf_info.curr_transfer_dir, turf_info.curr_transfer_amount);
-						turf_info.adjust_eq_movement(Some(&mut adj_info), dir, amt);
-						adj_info.curr_transfer_amount += turf_info.curr_transfer_amount;
-						turf_info.curr_transfer_amount = 0.0;
-					}
+
+		for cur_index in queue.drain(..).rev() {
+			let mut turf_info = {
+				let opt = info.get(&cur_index);
+				if opt.is_none() {
+					continue;
+				}
+				*opt.unwrap()
+			};
+			if turf_info.curr_transfer_amount != 0.0 && turf_info.curr_transfer_dir.is_some() {
+				if let Some(mut adj_info) = info.get_mut(&turf_info.curr_transfer_dir.unwrap()) {
+					adjust_eq_movement(
+						Some(cur_index),
+						turf_info.curr_transfer_dir,
+						turf_info.curr_transfer_amount,
+						eq_movement_graph,
+					);
+					adj_info.curr_transfer_amount += turf_info.curr_transfer_amount;
+					turf_info.curr_transfer_amount = 0.0;
 				}
 			}
+			info.entry(cur_index)
+				.and_modify(|cur_info| *cur_info = turf_info);
 		}
 	}
 }
 
 fn take_from_givers(
 	taker_turfs: &[RefMixWithID],
-	_giver_turfs: &[RefMixWithID],
-	turfs: &IndexMap<TurfID, TurfMixture, FxBuildHasher>,
-	max_x: i32,
-	max_y: i32,
-	info: &DashMap<TurfID, MonstermosInfo, FxBuildHasher>,
+	arena: &RwLockReadGuard<TurfGases>,
+	info: &mut HashMap<NodeIndex, MonstermosInfo, FxBuildHasher>,
+	eq_movement_graph: &mut DiGraphMap<Option<NodeIndex>, f32>,
 ) {
-	let mut queue: IndexMap<TurfID, &TurfMixture, FxBuildHasher> =
-		IndexMap::with_hasher(FxBuildHasher::default());
-
-	for &(i, m) in taker_turfs {
+	let mut queue: IndexSet<NodeIndex, FxBuildHasher> = Default::default();
+	for (&index, _) in taker_turfs {
 		let mut taker_info = {
-			let maybe_taker_orig = info.get_mut(i);
-			if maybe_taker_orig.is_none() {
-				continue;
-			}
-			let mut taker_info = maybe_taker_orig.unwrap();
-			taker_info.curr_transfer_dir = 6;
+			let taker_info = info.get_mut(&index).unwrap();
+			taker_info.curr_transfer_dir = None;
 			taker_info.curr_transfer_amount = 0.0;
 			*taker_info
 		};
-		queue.insert(*i, m);
+		queue.insert(index);
 		let mut queue_idx = 0;
-		while let Some((idx, turf)) = queue.get_index(queue_idx) {
+		while let Some(&cur_index) = queue.get_index(queue_idx) {
 			if taker_info.mole_delta >= 0.0 {
 				break;
 			}
-			for (j, loc) in adjacent_tile_ids_no_orig(turf.adjacency, *idx, max_x, max_y) {
+			for adj_index in arena.adjacent_node_ids_enabled(cur_index) {
 				if taker_info.mole_delta >= 0.0 {
 					break;
 				}
-				if let Some(mut adj_info) = info.get_mut(&loc) {
-					if let Some(adj_mix) = turfs
-						.get(&loc)
-						.and_then(|terf| terf.enabled().then(|| terf))
-					{
-						if queue.insert(loc, adj_mix).is_none() {
-							adj_info.curr_transfer_dir = OPP_DIR_INDEX[j as usize];
-							adj_info.curr_transfer_amount = 0.0;
-							if adj_info.mole_delta > 0.0 {
-								// this turf has gas we can succ. Time to succ.
-								if adj_info.mole_delta > -taker_info.mole_delta {
-									// they have enough gase
-									adj_info.curr_transfer_amount -= taker_info.mole_delta;
-									adj_info.mole_delta += taker_info.mole_delta;
-									taker_info.mole_delta = 0.0;
-								} else {
-									// they don't have neough gas
-									adj_info.curr_transfer_amount += adj_info.mole_delta;
-									taker_info.mole_delta += adj_info.mole_delta;
-									adj_info.mole_delta = 0.0;
-								}
+				if let Some(mut adj_info) = info.get_mut(&adj_index) {
+					if queue.insert(adj_index) {
+						adj_info.curr_transfer_dir = Some(cur_index);
+						adj_info.curr_transfer_amount = 0.0;
+						if adj_info.mole_delta > 0.0 {
+							// this turf has gas we can succ. Time to succ.
+							if adj_info.mole_delta > -taker_info.mole_delta {
+								// they have enough gase
+								adj_info.curr_transfer_amount -= taker_info.mole_delta;
+								adj_info.mole_delta += taker_info.mole_delta;
+								taker_info.mole_delta = 0.0;
+							} else {
+								// they don't have neough gas
+								adj_info.curr_transfer_amount += adj_info.mole_delta;
+								taker_info.mole_delta += adj_info.mole_delta;
+								adj_info.mole_delta = 0.0;
 							}
 						}
 					}
 				}
-				info.entry(*i).and_modify(|entry| *entry = taker_info);
+				info.entry(index).and_modify(|entry| *entry = taker_info);
 			}
 			queue_idx += 1;
 		}
-		for (idx, _) in queue.drain(..).rev() {
-			if let Some(mut turf_info) = info.get_mut(&idx) {
-				if turf_info.curr_transfer_amount != 0.0 && turf_info.curr_transfer_dir != 6 {
-					if let Some(mut adj_info) = info.get_mut(&adjacent_tile_id(
-						turf_info.curr_transfer_dir as u8,
-						idx,
-						max_x,
-						max_y,
-					)) {
-						let (dir, amt) =
-							(turf_info.curr_transfer_dir, turf_info.curr_transfer_amount);
-						turf_info.adjust_eq_movement(Some(&mut adj_info), dir, amt);
-						adj_info.curr_transfer_amount += turf_info.curr_transfer_amount;
-						turf_info.curr_transfer_amount = 0.0;
-					}
+		for cur_index in queue.drain(..).rev() {
+			let mut turf_info = {
+				let opt = info.get(&cur_index);
+				if opt.is_none() {
+					continue;
+				}
+				*opt.unwrap()
+			};
+			if turf_info.curr_transfer_amount != 0.0 && turf_info.curr_transfer_dir.is_some() {
+				if let Some(mut adj_info) = info.get_mut(&turf_info.curr_transfer_dir.unwrap()) {
+					adjust_eq_movement(
+						Some(cur_index),
+						turf_info.curr_transfer_dir,
+						turf_info.curr_transfer_amount,
+						eq_movement_graph,
+					);
+					adj_info.curr_transfer_amount += turf_info.curr_transfer_amount;
+					turf_info.curr_transfer_amount = 0.0;
 				}
 			}
+			info.entry(cur_index)
+				.and_modify(|cur_info| *cur_info = turf_info);
 		}
 	}
 }
 
-fn explosively_depressurize(
-	turf_idx: TurfID,
-	max_x: i32,
-	max_y: i32,
-	equalize_hard_turf_limit: usize,
-) -> DMResult {
-	let mut info: HashMap<TurfID, Cell<ReducedInfo>, FxBuildHasher> =
-		HashMap::with_hasher(FxBuildHasher::default());
-	let mut turfs: IndexSet<TurfID, FxBuildHasher> =
-		IndexSet::with_hasher(FxBuildHasher::default());
-	let mut progression_order: IndexSet<MixWithID, RandomState> =
-		IndexSet::with_hasher(RandomState::default());
-	let mut space_turfs: IndexSet<TurfID, FxBuildHasher> =
-		IndexSet::with_hasher(FxBuildHasher::default());
-	turfs.insert(turf_idx);
-	let mut warned_about_planet_atmos = false;
-	let mut cur_queue_idx = 0;
-	while cur_queue_idx < turfs.len() {
-		let i = turfs[cur_queue_idx];
-		cur_queue_idx += 1;
-		let m = {
-			let maybe = turf_gases().get(&i);
-			if maybe.is_none() {
-				continue;
-			}
-			*maybe.unwrap()
-		};
-		if m.planetary_atmos.is_some() {
-			warned_about_planet_atmos = true;
-			continue;
-		}
-		if m.is_immutable() {
-			if space_turfs.insert(i) {
-				unsafe { Value::turf_by_id_unchecked(i) }
-					.set(byond_string!("pressure_specific_target"), &unsafe {
-						Value::turf_by_id_unchecked(i)
-					})?;
-			}
-		} else {
-			if cur_queue_idx > equalize_hard_turf_limit {
-				continue;
-			}
-			for (_, loc) in adjacent_tile_ids(m.adjacency, i, max_x, max_y) {
-				let insert_success = {
-					if turf_gases().get(&loc).is_some() {
-						turfs.insert(loc)
-					} else {
-						false
+#[inline(never)]
+fn explosively_depressurize(initial_index: NodeIndex, equalize_hard_turf_limit: usize) -> DMResult {
+	//1st floodfill
+	let (space_turfs, warned_about_planet_atmos) = with_turf_gases_read(
+		|arena| -> Result<(IndexSet<NodeIndex, FxBuildHasher>, bool), Runtime> {
+			let mut cur_queue_idx = 0;
+			let mut warned_about_planet_atmos = false;
+			let mut space_turfs: IndexSet<NodeIndex, FxBuildHasher> = Default::default();
+			let mut turfs: IndexSet<NodeIndex, FxBuildHasher> = Default::default();
+			turfs.insert(initial_index);
+			while cur_queue_idx < turfs.len() {
+				let cur_index = turfs[cur_queue_idx];
+				cur_queue_idx += 1;
+				let cur_mixture = {
+					let maybe = arena.get(cur_index);
+					if maybe.is_none() {
+						continue;
 					}
+					*maybe.unwrap()
 				};
-				if insert_success {
-					unsafe { Value::turf_by_id_unchecked(i) }.call(
-						"consider_firelocks",
-						&[&unsafe { Value::turf_by_id_unchecked(loc) }],
-					)?;
+				if cur_mixture.planetary_atmos.is_some() {
+					warned_about_planet_atmos = true;
+					continue;
+				}
+				if cur_mixture.is_immutable() {
+					if space_turfs.insert(cur_index) {
+						unsafe { Value::turf_by_id_unchecked(cur_mixture.id) }
+							.set(byond_string!("pressure_specific_target"), &unsafe {
+								Value::turf_by_id_unchecked(cur_mixture.id)
+							})?;
+					}
+				} else {
+					if cur_queue_idx > equalize_hard_turf_limit {
+						continue;
+					}
+					for (adj_index, adj_mixture) in arena
+						.adjacent_node_ids(cur_index)
+						.filter_map(|index| Some((index, arena.get(index)?)))
+					{
+						if turfs.insert(adj_index) {
+							unsafe { Value::turf_by_id_unchecked(cur_mixture.id) }.call(
+								"consider_firelocks",
+								&[&unsafe { Value::turf_by_id_unchecked(adj_mixture.id) }],
+							)?;
+						}
+					}
+				}
+				if warned_about_planet_atmos {
+					break;
 				}
 			}
-		}
-		if warned_about_planet_atmos {
-			return Ok(Value::null()); // planet atmos > space
-		}
+			Ok((space_turfs, warned_about_planet_atmos))
+		},
+	)?;
+
+	if warned_about_planet_atmos {
+		return Ok(Value::null()); // planet atmos > space
 	}
-
-	process_aux_callbacks(crate::callbacks::TURFS);
-	process_aux_callbacks(crate::callbacks::ADJACENCIES);
-
 	if space_turfs.is_empty() {
 		return Ok(Value::null());
 	}
 
-	for i in space_turfs.iter() {
-		let maybe_turf = turf_gases().get(i);
-		if maybe_turf.is_none() {
-			continue;
-		}
-		let m = *maybe_turf.unwrap();
-		progression_order.insert((*i, m));
-	}
+	//actually update the damn arena to register the firelocks closing
+	process_aux_callbacks(crate::callbacks::TURFS);
+	process_aux_callbacks(crate::callbacks::ADJACENCIES);
 
-	cur_queue_idx = 0;
-	while cur_queue_idx < progression_order.len() {
-		let (i, m) = progression_order[cur_queue_idx];
-		cur_queue_idx += 1;
-		if cur_queue_idx > equalize_hard_turf_limit {
-			continue;
+	with_turf_gases_read(move |arena| {
+		let mut info: HashMap<NodeIndex, Cell<ReducedInfo>, FxBuildHasher> = Default::default();
+		let mut progression_order: IndexSet<MixWithID, RandomState> = Default::default();
+		for &cur_index in space_turfs.iter() {
+			let maybe_turf = arena.get(cur_index);
+			if maybe_turf.is_none() {
+				continue;
+			}
+			let cur_mixture = maybe_turf.unwrap();
+			progression_order.insert((cur_index, *cur_mixture));
 		}
-		for (j, loc) in adjacent_tile_ids(m.adjacency, i, max_x, max_y) {
-			if let Some(adj_m) = { turf_gases().get(&loc) } {
-				let adj_orig = info.entry(loc).or_default();
-				let mut adj_info = adj_orig.get();
-				if !adj_m.is_immutable() && progression_order.insert((loc, *adj_m)) {
-					adj_info.curr_transfer_dir = OPP_DIR_INDEX[j as usize];
-					adj_info.curr_transfer_amount = 0.0;
-					let cur_target_turf = unsafe { Value::turf_by_id_unchecked(i) }
-						.get(byond_string!("pressure_specific_target"))?;
-					unsafe { Value::turf_by_id_unchecked(loc) }
-						.set(byond_string!("pressure_specific_target"), &cur_target_turf)?;
-					adj_orig.set(adj_info);
+
+		let mut space_turf_len = 0;
+		let mut total_moles = 0.0;
+		let mut cur_queue_idx = 0;
+		//2nd floodfill
+		while cur_queue_idx < progression_order.len() {
+			let (cur_index, cur_mixture) = progression_order[cur_queue_idx];
+			cur_queue_idx += 1;
+
+			total_moles += cur_mixture.total_moles();
+			cur_mixture.is_immutable().then(|| space_turf_len += 1);
+
+			if cur_queue_idx > equalize_hard_turf_limit {
+				continue;
+			}
+
+			for adj_turf in arena.adjacent_node_ids(cur_index) {
+				if let Some(adj_mixture) = arena.get(adj_turf) {
+					let adj_orig = info.entry(adj_turf).or_default();
+					let mut adj_info = adj_orig.get();
+					if !adj_mixture.is_immutable()
+						&& progression_order.insert((adj_turf, *adj_mixture))
+					{
+						adj_info.curr_transfer_dir = Some(cur_index);
+						adj_info.curr_transfer_amount = 0.0;
+						let cur_target_turf =
+							unsafe { Value::turf_by_id_unchecked(cur_mixture.id) }
+								.get(byond_string!("pressure_specific_target"))?;
+						unsafe { Value::turf_by_id_unchecked(adj_mixture.id) }
+							.set(byond_string!("pressure_specific_target"), &cur_target_turf)?;
+						adj_orig.set(adj_info);
+					}
 				}
 			}
 		}
-	}
-	let hpd = auxtools::Value::globals()
-		.get(byond_string!("SSair"))?
-		.get_list(byond_string!("high_pressure_delta"))
-		.map_err(|_| {
-			runtime!(
-				"Attempt to interpret non-list value as list {} {}:{}",
-				std::file!(),
-				std::line!(),
-				std::column!()
-			)
-		})?;
-	for (i, m) in progression_order.iter().rev() {
-		let cur_orig = info.entry(*i).or_default();
-		let mut cur_info = cur_orig.get();
-		if cur_info.curr_transfer_dir == 6 {
-			continue;
-		}
-		let mut in_hpd = false;
-		for k in 1..=hpd.len() {
-			if let Ok(hpd_val) = hpd.get(k) {
-				if hpd_val == unsafe { Value::turf_by_id_unchecked(*i) } {
-					in_hpd = true;
-					break;
+
+		let _average_moles = total_moles / (progression_order.len() - space_turf_len) as f32;
+
+		let hpd = auxtools::Value::globals()
+			.get(byond_string!("SSair"))?
+			.get_list(byond_string!("high_pressure_delta"))
+			.map_err(|_| {
+				runtime!(
+					"Attempt to interpret non-list value as list {} {}:{}",
+					std::file!(),
+					std::line!(),
+					std::column!()
+				)
+			})?;
+
+		let get_dir = Proc::find(byond_string!("/proc/get_dir_multiz")).unwrap();
+
+		for (cur_index, cur_mixture) in progression_order.iter().rev() {
+			let cur_orig = info.entry(*cur_index).or_default();
+			let mut cur_info = cur_orig.get();
+			if cur_info.curr_transfer_dir.is_none() {
+				continue;
+			}
+			let mut in_hpd = false;
+			for k in 1..=hpd.len() {
+				if let Ok(hpd_val) = hpd.get(k) {
+					if hpd_val == unsafe { Value::turf_by_id_unchecked(cur_mixture.id) } {
+						in_hpd = true;
+						break;
+					}
 				}
 			}
-		}
-		if !in_hpd {
-			hpd.append(&unsafe { Value::turf_by_id_unchecked(*i) });
-		}
-		let loc = adjacent_tile_id(cur_info.curr_transfer_dir as u8, *i, max_x, max_y);
-		let mut sum = 0.0_f32;
+			if !in_hpd {
+				hpd.append(&unsafe { Value::turf_by_id_unchecked(cur_mixture.id) });
+			}
+			let adj_index = cur_info.curr_transfer_dir.unwrap();
 
-		if let Some(adj_m) = turf_gases().get(&loc) {
-			sum = adj_m.total_moles();
-		};
+			let adj_mixture = arena.get(adj_index).unwrap();
+			let sum = adj_mixture.total_moles();
 
-		cur_info.curr_transfer_amount += sum;
-		cur_orig.set(cur_info);
+			cur_info.curr_transfer_amount += sum;
+			cur_orig.set(cur_info);
 
-		let adj_orig = info.entry(loc).or_default();
-		let mut adj_info = adj_orig.get();
+			let adj_orig = info.entry(adj_index).or_default();
+			let mut adj_info = adj_orig.get();
 
-		adj_info.curr_transfer_amount += cur_info.curr_transfer_amount;
-		adj_orig.set(adj_info);
+			adj_info.curr_transfer_amount += cur_info.curr_transfer_amount;
+			adj_orig.set(adj_info);
 
-		let byond_turf = unsafe { Value::turf_by_id_unchecked(*i) };
+			let byond_turf = unsafe { Value::turf_by_id_unchecked(cur_mixture.id) };
+			let byond_turf_adj = unsafe { Value::turf_by_id_unchecked(adj_mixture.id) };
 
-		byond_turf.set(
-			byond_string!("pressure_difference"),
-			Value::from(cur_info.curr_transfer_amount),
-		)?;
-		byond_turf.set(
-			byond_string!("pressure_direction"),
-			Value::from((1 << cur_info.curr_transfer_dir) as f32),
-		)?;
-
-		if adj_info.curr_transfer_dir == 6 {
-			let byond_turf_adj = unsafe { Value::turf_by_id_unchecked(loc) };
-			byond_turf_adj.set(
+			byond_turf.set(
 				byond_string!("pressure_difference"),
-				Value::from(adj_info.curr_transfer_amount),
+				Value::from(cur_info.curr_transfer_amount),
 			)?;
-			byond_turf_adj.set(
+			byond_turf.set(
 				byond_string!("pressure_direction"),
-				Value::from((1 << cur_info.curr_transfer_dir) as f32),
+				get_dir.call(&[&byond_turf, &byond_turf_adj])?,
 			)?;
+
+			if adj_info.curr_transfer_dir.is_none() {
+				byond_turf_adj.set(
+					byond_string!("pressure_difference"),
+					Value::from(adj_info.curr_transfer_amount),
+				)?;
+				byond_turf_adj.set(
+					byond_string!("pressure_direction"),
+					get_dir.call(&[&byond_turf_adj, &byond_turf])?,
+				)?;
+			}
+
+			#[cfg(not(feature = "katmos_slow_decompression"))]
+			{
+				cur_mixture.clear_air();
+			}
+			#[cfg(feature = "katmos_slow_decompression")]
+			{
+				const DECOMP_REMOVE_RATIO: f32 = 4_f32;
+				cur_mixture.clear_vol((_average_moles / DECOMP_REMOVE_RATIO).abs());
+			}
+
+			byond_turf.call("handle_decompression_floor_rip", &[&Value::from(sum)])?;
 		}
-		m.clear_air();
-		byond_turf.call("handle_decompression_floor_rip", &[&Value::from(sum)])?;
-	}
+		Ok(())
+	})?;
+
 	Ok(Value::null())
-	//	if (total_gases_deleted / turfs.len() as f32) > 20.0 && turfs.len() > 10 { // logging I guess
-	//	}
 }
 
 // Clippy go away, this type is only used once
 #[allow(clippy::type_complexity)]
 fn flood_fill_equalize_turfs(
-	i: TurfID,
-	m: TurfMixture,
-	max_x: i32,
-	max_y: i32,
+	index: NodeIndex,
 	equalize_hard_turf_limit: usize,
-	found_turfs: &mut HashSet<TurfID, FxBuildHasher>,
+	found_turfs: &mut HashSet<NodeIndex, FxBuildHasher>,
+	arena: &RwLockReadGuard<TurfGases>,
 ) -> Option<(
-	IndexMap<TurfID, TurfMixture, FxBuildHasher>,
-	IndexMap<TurfID, TurfMixture, FxBuildHasher>,
+	IndexMap<NodeIndex, TurfMixture, FxBuildHasher>,
+	IndexSet<NodeIndex, FxBuildHasher>,
 	f64,
 )> {
-	let mut turfs: IndexMap<TurfID, TurfMixture, FxBuildHasher> =
-		IndexMap::with_hasher(FxBuildHasher::default());
-	let mut border_turfs: std::collections::VecDeque<MixWithID> = std::collections::VecDeque::new();
-	let mut planet_turfs: IndexMap<TurfID, TurfMixture, FxBuildHasher> =
-		IndexMap::with_hasher(FxBuildHasher::default());
+	let mut turfs: IndexMap<NodeIndex, TurfMixture, FxBuildHasher> = Default::default();
+	let mut border_turfs: std::collections::VecDeque<(NodeIndex, TurfMixture)> = Default::default();
+	let mut planet_turfs: IndexSet<NodeIndex, FxBuildHasher> = Default::default();
 	let sender = byond_callback_sender();
 	let mut total_moles = 0.0_f64;
-	border_turfs.push_back((i, m));
-	found_turfs.insert(i);
+	border_turfs.push_back((index, *arena.get(index).unwrap()));
+	found_turfs.insert(index);
 	let mut ignore_zone = false;
-	while let Some((cur_idx, cur_turf)) = border_turfs.pop_front() {
+	while let Some((cur_index, cur_mixture)) = border_turfs.pop_front() {
+		let cur_turf = arena.get(cur_index).unwrap();
 		if cur_turf.planetary_atmos.is_some() {
-			planet_turfs.insert(cur_idx, cur_turf);
+			planet_turfs.insert(cur_index);
 			continue;
 		}
 		total_moles += cur_turf.total_moles() as f64;
-		for (_, loc) in adjacent_tile_ids(cur_turf.adjacency, cur_idx, max_x, max_y) {
-			if found_turfs.insert(loc) {
-				let result = turf_gases().try_get(&loc);
-				if result.is_locked() {
-					ignore_zone = true;
-					continue;
-				}
-				if let Some(adj_turf) = result.try_unwrap() {
-					if adj_turf.enabled() {
-						border_turfs.push_back((loc, *adj_turf.value()));
+
+		for adj_index in arena.adjacent_node_ids(cur_index) {
+			if found_turfs.insert(adj_index) {
+				if let Some(adj_mixture) = arena.get(adj_index) {
+					if adj_mixture.enabled() {
+						border_turfs.push_back((adj_index, *adj_mixture));
 					}
-					if adj_turf.value().is_immutable() {
+					if adj_mixture.is_immutable() {
 						// Uh oh! looks like someone opened an airlock to space! TIME TO SUCK ALL THE AIR OUT!!!
 						// NOT ONE OF YOU IS GONNA SURVIVE THIS
 						// (I just made explosions less laggy, you're welcome)
 						if !ignore_zone {
 							drop(sender.send(Box::new(move || {
-								explosively_depressurize(i, max_x, max_y, equalize_hard_turf_limit)
+								explosively_depressurize(adj_index, equalize_hard_turf_limit)
 							})));
 						}
 						ignore_zone = true;
@@ -671,22 +633,25 @@ fn flood_fill_equalize_turfs(
 				}
 			}
 		}
-		turfs.insert(cur_idx, cur_turf);
+		turfs.insert(cur_index, cur_mixture);
 	}
 	(!ignore_zone).then(|| (turfs, planet_turfs, total_moles))
 }
 
 fn process_planet_turfs(
-	planet_turfs: &IndexMap<TurfID, TurfMixture, FxBuildHasher>,
-	turfs: &IndexMap<TurfID, TurfMixture, FxBuildHasher>,
+	planet_turfs: &IndexSet<NodeIndex, FxBuildHasher>,
+	arena: &RwLockReadGuard<TurfGases>,
 	average_moles: f32,
-	max_x: i32,
-	max_y: i32,
 	equalize_hard_turf_limit: usize,
-	info: &DashMap<TurfID, MonstermosInfo, FxBuildHasher>,
+	info: &mut HashMap<NodeIndex, MonstermosInfo, FxBuildHasher>,
+	eq_movement_graph: &mut DiGraphMap<Option<NodeIndex>, f32>,
 ) {
 	let sender = byond_callback_sender();
-	let sample_turf = planet_turfs[0];
+	let sample_turf = arena.get(planet_turfs[0]);
+	if sample_turf.is_none() {
+		return;
+	}
+	let sample_turf = sample_turf.unwrap();
 	let sample_planet_atmos = sample_turf.planetary_atmos;
 	if sample_planet_atmos.is_none() {
 		return;
@@ -700,177 +665,194 @@ fn process_planet_turfs(
 	let planet_sum = maybe_planet_sum.unwrap().value().total_moles();
 	let target_delta = planet_sum - average_moles;
 
-	let mut progression_order: IndexSet<TurfID, FxBuildHasher> =
-		IndexSet::with_hasher(FxBuildHasher::default());
+	let mut progression_order: IndexSet<NodeIndex, FxBuildHasher> = Default::default();
 
-	for (i, _) in planet_turfs.iter() {
-		progression_order.insert(*i);
-		let mut cur_info = info.entry(*i).or_default();
-		cur_info.curr_transfer_dir = 6;
+	for cur_index in planet_turfs.iter() {
+		progression_order.insert(*cur_index);
+		let mut cur_info = info.entry(*cur_index).or_default();
+		cur_info.curr_transfer_dir = None;
 	}
 	// now build a map of where the path to a planet turf is for each tile.
 	let mut queue_idx = 0;
 	while queue_idx < progression_order.len() {
-		let i = progression_order[queue_idx];
+		let cur_index = progression_order[queue_idx];
 		queue_idx += 1;
-		let maybe_m = turfs.get(&i);
+		let maybe_m = arena.get(cur_index);
 		if maybe_m.is_none() {
-			info.entry(i)
+			info.entry(cur_index)
 				.and_modify(|entry| *entry = MonstermosInfo::default());
 			continue;
 		}
-		let m = *maybe_m.unwrap();
-		for (j, loc) in adjacent_tile_ids_no_orig(m.adjacency, i, max_x, max_y) {
-			if let Some(mut adj_info) = info.get_mut(&loc) {
+		let cur_mixture_id = maybe_m.unwrap().id;
+		for adj_index in arena.adjacent_node_ids(cur_index) {
+			if let Some(mut adj_info) = info.get_mut(&adj_index) {
+				let adj_mixture_id = arena.get(adj_index).unwrap().id;
 				if queue_idx < equalize_hard_turf_limit {
 					drop(sender.try_send(Box::new(move || {
-						let that_turf = unsafe { Value::turf_by_id_unchecked(loc) };
-						let this_turf = unsafe { Value::turf_by_id_unchecked(i) };
-						this_turf.call("consider_firelocks", &[&that_turf])?;
+						let this_turf = unsafe { Value::turf_by_id_unchecked(cur_mixture_id) };
+						this_turf.call(
+							"consider_firelocks",
+							&[&unsafe { Value::turf_by_id_unchecked(adj_mixture_id) }],
+						)?;
 						Ok(Value::null())
 					})));
 				}
-				if let Some(adj) = turfs
-					.get(&loc)
+				if let Some(adj_mixture) = arena
+					.get(adj_index)
 					.and_then(|terf| terf.enabled().then(|| terf))
 				{
-					if !progression_order.insert(loc) || adj.planetary_atmos.is_some() {
+					if !progression_order.insert(adj_index) || adj_mixture.planetary_atmos.is_some()
+					{
 						continue;
 					}
-					adj_info.curr_transfer_dir = OPP_DIR_INDEX[j as usize];
+					adj_info.curr_transfer_dir = Some(cur_index);
 				}
 			}
 		}
 	}
-	for i in progression_order.iter().rev() {
-		if turfs.get(i).is_none() {
+	for &cur_index in progression_order.iter().rev() {
+		if arena.get(cur_index).is_none() {
 			continue;
 		}
-		if let Some(mut cur_info) = info.get_mut(i) {
-			let airflow = cur_info.mole_delta - target_delta;
-			let dir = cur_info.curr_transfer_dir;
-			if cur_info.curr_transfer_dir == 6 {
-				cur_info.adjust_eq_movement(None, dir, airflow);
-				cur_info.mole_delta = target_delta;
-			} else if let Some(mut adj_info) = info.get_mut(&adjacent_tile_id(
-				cur_info.curr_transfer_dir as u8,
-				*i,
-				max_x,
-				max_y,
-			)) {
-				cur_info.adjust_eq_movement(Some(&mut adj_info), dir, airflow);
-				adj_info.mole_delta += airflow;
-				cur_info.mole_delta = target_delta;
+		let mut cur_info = {
+			if let Some(opt) = info.get(&cur_index) {
+				*opt
+			} else {
+				continue;
 			}
+		};
+		let airflow = cur_info.mole_delta - target_delta;
+		if cur_info.curr_transfer_dir.is_none() {
+			adjust_eq_movement(Some(cur_index), None, airflow, eq_movement_graph);
+			cur_info.mole_delta = target_delta;
+		} else if let Some(mut adj_info) = info.get_mut(&cur_info.curr_transfer_dir.unwrap()) {
+			adjust_eq_movement(
+				Some(cur_index),
+				cur_info.curr_transfer_dir,
+				airflow,
+				eq_movement_graph,
+			);
+			adj_info.mole_delta += airflow;
+			cur_info.mole_delta = target_delta;
 		}
+		info.entry(cur_index).and_modify(|info| *info = cur_info);
 	}
 }
 
 pub(crate) fn equalize(
-	max_x: i32,
-	max_y: i32,
 	equalize_hard_turf_limit: usize,
-	high_pressure_turfs: &BTreeSet<TurfID>,
+	high_pressure_turfs: &[NodeIndex],
 ) -> usize {
 	let turfs_processed: AtomicUsize = AtomicUsize::new(0);
-	let mut found_turfs: HashSet<TurfID, FxBuildHasher> =
-		HashSet::with_hasher(FxBuildHasher::default());
-	let zoned_turfs = high_pressure_turfs
-		.iter()
-		.filter_map(|i| {
-			if found_turfs.contains(i) {
-				return None;
-			};
-			let m = *turf_gases().try_get(i).try_unwrap()?;
-			if !m.enabled()
-				|| m.adjacency == 0
-				|| GasArena::with_all_mixtures(|all_mixtures| {
-					let our_moles = all_mixtures[m.mix].read().total_moles();
+	let mut found_turfs: HashSet<NodeIndex, FxBuildHasher> = Default::default();
+	with_turf_gases_read(|arena| {
+		let zoned_turfs = high_pressure_turfs
+			.iter()
+			.filter_map(|&cur_index| {
+				//is this turf already visited?
+				if found_turfs.contains(&cur_index) {
+					return None;
+				};
+
+				//is this turf exists/enabled/have adjacencies?
+				let cur_mixture = *arena.get(cur_index)?;
+				if !cur_mixture.enabled() || arena.adjacent_node_ids(cur_index).next().is_none() {
+					return None;
+				}
+
+				//does this turf or its adjacencies have enough moles to share?
+				if GasArena::with_all_mixtures(|all_mixtures| {
+					let our_moles = all_mixtures[cur_mixture.mix].read().total_moles();
 					our_moles < 10.0
-						|| m.adjacent_mixes(all_mixtures).all(|lock| {
+						|| arena.adjacent_mixes(cur_index, all_mixtures).all(|lock| {
 							(lock.read().total_moles() - our_moles).abs()
 								< MINIMUM_MOLES_DELTA_TO_MOVE
 						})
 				}) {
-				return None;
-			}
-			flood_fill_equalize_turfs(
-				*i,
-				m,
-				max_x,
-				max_y,
-				equalize_hard_turf_limit,
-				&mut found_turfs,
-			)
-		})
-		.collect::<Vec<_>>();
-
-	let turfs = zoned_turfs
-		.into_par_iter()
-		.map(|(turfs, planet_turfs, total_moles)| {
-			let info: DashMap<TurfID, MonstermosInfo, FxBuildHasher> =
-				DashMap::with_hasher(FxBuildHasher::default());
-			let average_moles = (total_moles / (turfs.len() - planet_turfs.len()) as f64) as f32;
-
-			let (mut giver_turfs, mut taker_turfs): (Vec<_>, Vec<_>) = turfs
-				.par_iter()
-				.filter(|&(i, m)| {
-					{
-						let mut cur_info = info.entry(*i).or_default();
-						cur_info.mole_delta = m.total_moles() - average_moles;
-					}
-					m.planetary_atmos.is_none()
-				})
-				.partition(|&(i, _)| info.entry(*i).or_default().mole_delta > 0.0);
-
-			let log_n = ((turfs.len() as f32).log2().floor()) as usize;
-			if giver_turfs.len() > log_n && taker_turfs.len() > log_n {
-				for (&i, m) in &turfs {
-					monstermos_fast_process(i, m, &turfs, max_x, max_y, &info);
+					return None;
 				}
-				giver_turfs.clear();
-				taker_turfs.clear();
 
-				giver_turfs.par_extend(turfs.par_iter().filter(|&(i, m)| {
-					info.entry(*i).or_default().mole_delta > 0.0 && m.planetary_atmos.is_none()
-				}));
-
-				taker_turfs.par_extend(turfs.par_iter().filter(|&(i, m)| {
-					info.entry(*i).or_default().mole_delta <= 0.0 && m.planetary_atmos.is_none()
-				}));
-			}
-
-			// alright this is the part that can become O(n^2).
-			if giver_turfs.len() < taker_turfs.len() {
-				// as an optimization, we choose one of two methods based on which list is smaller.
-				give_to_takers(&giver_turfs, &taker_turfs, &turfs, max_x, max_y, &info);
-			} else {
-				take_from_givers(&taker_turfs, &giver_turfs, &turfs, max_x, max_y, &info);
-			}
-			if planet_turfs.is_empty() {
-				turfs_processed.fetch_add(turfs.len(), std::sync::atomic::Ordering::Relaxed);
-			} else {
-				turfs_processed.fetch_add(
-					turfs.len() + planet_turfs.len(),
-					std::sync::atomic::Ordering::Relaxed,
-				);
-				process_planet_turfs(
-					&planet_turfs,
-					&turfs,
-					average_moles,
-					max_x,
-					max_y,
+				flood_fill_equalize_turfs(
+					cur_index,
 					equalize_hard_turf_limit,
-					&info,
-				);
-			}
-			(turfs, info)
-		})
-		.collect::<Vec<_>>();
+					&mut found_turfs,
+					&arena,
+				)
+			})
+			.collect::<Vec<_>>();
 
-	turfs.par_iter().for_each(|(turf, info)| {
-		turf.iter().for_each(|(i, m)| {
-			finalize_eq(*i, m, turf, max_x, max_y, info);
+		let turfs = zoned_turfs
+			.into_par_iter()
+			.map(|(turfs, planet_turfs, total_moles)| {
+				let mut graph: DiGraphMap<Option<NodeIndex>, f32> = Default::default();
+				let average_moles =
+					(total_moles / (turfs.len() - planet_turfs.len()) as f64) as f32;
+
+				let mut info = turfs
+					.par_iter()
+					.map(|(&index, mixture)| {
+						let mut cur_info = MonstermosInfo::default();
+						cur_info.mole_delta = mixture.total_moles() - average_moles;
+						(index, cur_info)
+					})
+					.collect::<HashMap<_, _, FxBuildHasher>>();
+
+				let (mut giver_turfs, mut taker_turfs): (Vec<_>, Vec<_>) = turfs
+					.iter()
+					.filter(|(_, cur_mixture)| cur_mixture.planetary_atmos.is_none())
+					.partition(|(i, _)| info.get(i).unwrap().mole_delta > 0.0);
+
+				let log_n = ((turfs.len() as f32).log2().floor()) as usize;
+				if giver_turfs.len() > log_n && taker_turfs.len() > log_n {
+					for (&cur_index, _) in &turfs {
+						monstermos_fast_process(cur_index, &arena, &mut info, &mut graph);
+					}
+
+					giver_turfs.clear();
+					taker_turfs.clear();
+
+					giver_turfs.extend(turfs.iter().filter(|(cur_index, cur_mixture)| {
+						info.get(cur_index).unwrap().mole_delta > 0.0
+							&& cur_mixture.planetary_atmos.is_none()
+					}));
+
+					taker_turfs.extend(turfs.iter().filter(|(cur_index, cur_mixture)| {
+						info.get(cur_index).unwrap().mole_delta <= 0.0
+							&& cur_mixture.planetary_atmos.is_none()
+					}));
+				}
+
+				// alright this is the part that can become O(n^2).
+				if giver_turfs.len() < taker_turfs.len() {
+					// as an optimization, we choose one of two methods based on which list is smaller.
+					give_to_takers(&giver_turfs, &arena, &mut info, &mut graph);
+				} else {
+					take_from_givers(&taker_turfs, &arena, &mut info, &mut graph);
+				}
+				if planet_turfs.is_empty() {
+					turfs_processed.fetch_add(turfs.len(), std::sync::atomic::Ordering::Relaxed);
+				} else {
+					turfs_processed.fetch_add(
+						turfs.len() + planet_turfs.len(),
+						std::sync::atomic::Ordering::Relaxed,
+					);
+					process_planet_turfs(
+						&planet_turfs,
+						&arena,
+						average_moles,
+						equalize_hard_turf_limit,
+						&mut info,
+						&mut graph,
+					);
+				}
+				(turfs, info, graph)
+			})
+			.collect::<Vec<_>>();
+
+		turfs.into_par_iter().for_each(|(turf, info, mut graph)| {
+			turf.iter().for_each(|(&cur_index, cur_mixture)| {
+				finalize_eq(cur_index, cur_mixture, &arena, &info, &mut graph);
+			});
 		});
 	});
 	turfs_processed.load(std::sync::atomic::Ordering::Relaxed)

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -567,26 +567,25 @@ fn fdm(fdm_max_steps: i32, equalize_enabled: bool) -> (Vec<NodeIndex>, Vec<NodeI
 fn excited_group_processing(pressure_goal: f32, low_pressure_turfs: &Vec<NodeIndex>) -> usize {
 	let mut found_turfs: HashSet<NodeIndex, FxBuildHasher> = Default::default();
 	with_turf_gases_read(|arena| {
-		GasArena::with_all_mixtures(|all_mixtures| {
-			for &initial_turf in low_pressure_turfs {
-				if found_turfs.contains(&initial_turf) {
+		for &initial_turf in low_pressure_turfs {
+			if found_turfs.contains(&initial_turf) {
+				continue;
+			}
+			let initial_mix_ref = {
+				let maybe_initial_mix_ref = arena.get(initial_turf);
+				if maybe_initial_mix_ref.is_none() {
 					continue;
 				}
-				let initial_mix_ref = {
-					let maybe_initial_mix_ref = arena.get(initial_turf);
-					if maybe_initial_mix_ref.is_none() {
-						continue;
-					}
-					*maybe_initial_mix_ref.unwrap()
-				};
-				let mut border_turfs: VecDeque<NodeIndex> = VecDeque::with_capacity(40);
-				let mut turfs: Vec<TurfMixture> = Vec::with_capacity(200);
-				let mut min_pressure = initial_mix_ref.return_pressure();
-				let mut max_pressure = min_pressure;
-				let mut fully_mixed = Mixture::new();
-				border_turfs.push_back(initial_turf);
-				found_turfs.insert(initial_turf);
-
+				*maybe_initial_mix_ref.unwrap()
+			};
+			let mut border_turfs: VecDeque<NodeIndex> = VecDeque::with_capacity(40);
+			let mut turfs: Vec<TurfMixture> = Vec::with_capacity(200);
+			let mut min_pressure = initial_mix_ref.return_pressure();
+			let mut max_pressure = min_pressure;
+			let mut fully_mixed = Mixture::new();
+			border_turfs.push_back(initial_turf);
+			found_turfs.insert(initial_turf);
+			GasArena::with_all_mixtures(|all_mixtures| {
 				loop {
 					if turfs.len() >= 2500 {
 						break;
@@ -628,8 +627,8 @@ fn excited_group_processing(pressure_goal: f32, low_pressure_turfs: &Vec<NodeInd
 						}
 					});
 				}
-			}
-		});
+			});
+		}
 	});
 	found_turfs.len()
 }

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
 
 use auxtools::*;
 
@@ -15,6 +15,8 @@ use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use parking_lot::{Once, RwLock};
 
 use crate::callbacks::process_aux_callbacks;
+
+use tinyvec::TinyVec;
 
 lazy_static::lazy_static! {
 	static ref TURF_CHANNEL: (
@@ -170,16 +172,12 @@ fn _process_turf_start() -> Result<(), String> {
 		rayon::spawn(|| loop {
 			//this will block until process_turfs is called
 			let info = with_processing_callback_receiver(|receiver| receiver.recv().unwrap());
-			TASKS_RUNNING.fetch_add(1, Ordering::SeqCst);
+			TASKS_RUNNING.fetch_add(1, Ordering::Acquire);
 			let sender = byond_callback_sender();
 			let (low_pressure_turfs, high_pressure_turfs) = {
 				let start_time = Instant::now();
-				let (low_pressure_turfs, high_pressure_turfs) = fdm(
-					info.max_x,
-					info.max_y,
-					info.fdm_max_steps,
-					info.equalize_enabled,
-				);
+				let (low_pressure_turfs, high_pressure_turfs) =
+					fdm(info.fdm_max_steps, info.equalize_enabled);
 				let bench = start_time.elapsed().as_millis();
 				let (lpt, hpt) = (low_pressure_turfs.len(), high_pressure_turfs.len());
 				drop(sender.try_send(Box::new(move || {
@@ -208,12 +206,8 @@ fn _process_turf_start() -> Result<(), String> {
 			};
 			{
 				let start_time = Instant::now();
-				let processed_turfs = excited_group_processing(
-					info.max_x,
-					info.max_y,
-					info.group_pressure_goal,
-					&low_pressure_turfs,
-				);
+				let processed_turfs =
+					excited_group_processing(info.group_pressure_goal, &low_pressure_turfs);
 				let bench = start_time.elapsed().as_millis();
 				drop(sender.try_send(Box::new(move || {
 					let ssair = auxtools::Value::globals().get(byond_string!("SSair"))?;
@@ -245,32 +239,27 @@ fn _process_turf_start() -> Result<(), String> {
 					#[cfg(feature = "putnamos")]
 					{
 						super::putnamos::equalize(
-							info.equalize_turf_limit,
-							info.equalize_hard_turf_limit,
-							info.max_x,
-							info.max_y,
-							&high_pressure_turfs,
+							equalize_turf_limit,
+							equalize_hard_turf_limit,
+							max_x,
+							max_y,
+							high_pressure_turfs,
 						)
 					}
 					#[cfg(feature = "monstermos")]
 					{
 						super::monstermos::equalize(
-							info.equalize_turf_limit,
-							info.equalize_hard_turf_limit,
-							info.max_x,
-							info.max_y,
-							&high_pressure_turfs,
-							info.planet_enabled,
+							equalize_turf_limit,
+							equalize_hard_turf_limit,
+							max_x,
+							max_y,
+							high_pressure_turfs,
+							planet_enabled,
 						)
 					}
 					#[cfg(feature = "katmos")]
 					{
-						super::katmos::equalize(
-							info.max_x,
-							info.max_y,
-							info.equalize_hard_turf_limit,
-							&high_pressure_turfs,
-						)
+						super::katmos::equalize(info.equalize_hard_turf_limit, &high_pressure_turfs)
 					}
 					#[cfg(not(feature = "equalization"))]
 					{
@@ -325,21 +314,26 @@ fn _process_turf_start() -> Result<(), String> {
 					Ok(Value::null())
 				})));
 			}
-			TASKS_RUNNING.fetch_sub(1, Ordering::SeqCst);
+			TASKS_RUNNING.fetch_sub(1, Ordering::Release);
 		});
 	});
 	Ok(())
 }
 
 // Compares with neighbors, returning early if any of them are valid.
-fn should_process(m: TurfMixture, all_mixtures: &[RwLock<Mixture>]) -> bool {
-	m.adjacency > 0
-		&& m.enabled()
+fn should_process(
+	index: NodeIndex,
+	mixture: &TurfMixture,
+	all_mixtures: &[RwLock<Mixture>],
+	arena: &RwLockReadGuard<TurfGases>,
+) -> bool {
+	arena.adjacent_infos(index).next().is_some()
+		&& mixture.enabled()
 		&& all_mixtures
-			.get(m.mix)
+			.get(mixture.mix)
 			.and_then(RwLock::try_read)
 			.map_or(false, |gas| {
-				for entry in m.adjacent_mixes(all_mixtures) {
+				for entry in arena.adjacent_mixes(index, all_mixtures) {
 					if let Some(mix) = entry.try_read() {
 						if gas.temperature_compare(&mix)
 							|| gas.compare_with(&mix, MINIMUM_MOLES_DELTA_TO_MOVE)
@@ -350,7 +344,8 @@ fn should_process(m: TurfMixture, all_mixtures: &[RwLock<Mixture>]) -> bool {
 						return false;
 					}
 				}
-				m.planetary_atmos
+				mixture
+					.planetary_atmos
 					.and_then(|id| planetary_atmos().try_get(&id).try_unwrap())
 					.map_or(false, |planet_atmos_entry| {
 						let planet_atmos = planet_atmos_entry.value();
@@ -364,12 +359,11 @@ fn should_process(m: TurfMixture, all_mixtures: &[RwLock<Mixture>]) -> bool {
 // Clippy go away, this type is only used once
 #[allow(clippy::type_complexity)]
 fn process_cell(
-	i: TurfID,
-	m: TurfMixture,
-	max_x: i32,
-	max_y: i32,
+	index: NodeIndex,
+	mixture: TurfMixture,
 	all_mixtures: &[RwLock<Mixture>],
-) -> Option<(TurfID, TurfMixture, Mixture, [(TurfID, f32); 6], i32)> {
+	arena: &RwLockReadGuard<TurfGases>,
+) -> Option<(NodeIndex, Mixture, TinyVec<[(TurfID, f32); 6]>, i32)> {
 	let mut adj_amount = 0;
 	/*
 		Getting write locks is potential danger zone,
@@ -377,7 +371,7 @@ fn process_cell(
 		absolutely need to. Saving is fast enough.
 	*/
 	let mut end_gas = Mixture::from_vol(crate::constants::CELL_VOLUME);
-	let mut pressure_diffs: [(TurfID, f32); 6] = Default::default();
+	let mut pressure_diffs: TinyVec<[(TurfID, f32); 6]> = Default::default();
 	/*
 		The pressure here is negative
 		because we're going to be adding it
@@ -388,17 +382,18 @@ fn process_cell(
 		due to the pressure gradient.
 		Technically that's ρν², but, like, video games.
 	*/
-	for (j, loc, entry) in m.adjacent_mixes_with_adj_info(all_mixtures, i, max_x, max_y) {
+	for (&loc, entry) in arena.adjacent_mixes_with_adj_ids(index, all_mixtures) {
 		match entry.try_read() {
 			Some(mix) => {
 				end_gas.merge(&mix);
 				adj_amount += 1;
-				pressure_diffs[j as usize] = (loc, -mix.return_pressure() * GAS_DIFFUSION_CONSTANT);
+				pressure_diffs.push((loc, -mix.return_pressure() * GAS_DIFFUSION_CONSTANT));
 			}
 			None => return None, // this would lead to inconsistencies--no bueno
 		}
 	}
-	if let Some(planet_atmos_entry) = m
+
+	if let Some(planet_atmos_entry) = mixture
 		.planetary_atmos
 		.and_then(|id| planetary_atmos().try_get(&id).try_unwrap())
 	{
@@ -422,215 +417,220 @@ fn process_cell(
 		but I digress.)
 	*/
 	end_gas.multiply(GAS_DIFFUSION_CONSTANT);
-	Some((i, m, end_gas, pressure_diffs, adj_amount))
+	Some((index, end_gas, pressure_diffs, adj_amount))
 }
 
 // Solving the heat equation using a Finite Difference Method, an iterative stencil loop.
-fn fdm(
-	max_x: i32,
-	max_y: i32,
-	fdm_max_steps: i32,
-	equalize_enabled: bool,
-) -> (BTreeSet<TurfID>, BTreeSet<TurfID>) {
+fn fdm(fdm_max_steps: i32, equalize_enabled: bool) -> (Vec<NodeIndex>, Vec<NodeIndex>) {
 	/*
 		This is the replacement system for LINDA. LINDA requires a lot of bookkeeping,
 		which, when coefficient-wise operations are this fast, is all just unnecessary overhead.
 		This is a much simpler FDM system, basically like LINDA but without its most important feature,
 		sleeping turfs, which is why I've renamed it to fdm.
 	*/
-	let mut low_pressure_turfs: BTreeSet<TurfID> = BTreeSet::new();
-	let mut high_pressure_turfs: BTreeSet<TurfID> = BTreeSet::new();
+	let mut low_pressure_turfs: Vec<NodeIndex> = Vec::new();
+	let mut high_pressure_turfs: Vec<NodeIndex> = Vec::new();
 	let mut cur_count = 1;
-	loop {
-		if cur_count > fdm_max_steps {
-			break;
-		}
-		GasArena::with_all_mixtures(|all_mixtures| {
-			let turfs_to_save = turf_gases()
-				/*
-					This uses DashMap's rayon feature to parallelize the process.
-					The speedup gained from this is actually linear
-					with the amount of cores the CPU has, which, to be frank,
-					is way better than I was expecting, even though this operation
-					is technically embarassingly parallel. It'll probably reach
-					some maximum due to the global turf mixture lock access,
-					but it's already blazingly fast on my i7, so it should be fine.
-				*/
-				.par_iter()
-				.map(|entry| {
-					let (&i, &m) = entry.pair();
-					(i, m)
-				})
-				.filter(|&(_, m)| should_process(m, all_mixtures))
-				.filter_map(|(i, m)| process_cell(i, m, max_x, max_y, all_mixtures))
-				.collect::<Vec<_>>();
-			/*
-				For the optimization-heads reading this: this is not an unnecessary collect().
-				Saving all this to the turfs_to_save vector is, in fact, the reason
-				that gases don't need an archive anymore--this *is* the archival step,
-				simultaneously saving how the gases will change after the fact.
-				In short: the above actually needs to finish before the below starts
-				for consistency, so collect() is desired. This has been tested, by the way.
-			*/
-			let (low_pressure, high_pressure): (Vec<_>, Vec<_>) = turfs_to_save
-				.par_iter()
-				.filter_map(|(i, m, end_gas, mut pressure_diffs, adj_amount)| {
-					all_mixtures.get(m.mix).map(|entry| {
-						let mut max_diff = 0.0_f32;
-						let moved_pressure = {
-							let gas = entry.read();
-							gas.return_pressure() * GAS_DIFFUSION_CONSTANT
-						};
-						for pressure_diff in &mut pressure_diffs {
-							// pressure_diff.1 here was set to a negative above, so we just add.
-							pressure_diff.1 += moved_pressure;
-							max_diff = max_diff.max(pressure_diff.1.abs());
-						}
-						/*
-							1.0 - GAS_DIFFUSION_CONSTANT * adj_amount is going to be
-							precisely equal to the amount the surrounding tiles'
-							end_gas have "taken" from this tile--
-							they didn't actually take anything, just calculated
-							how much would be. This is the "taking" step.
-							Just to illustrate: say you have a turf with 3 neighbors.
-							Each of those neighbors will have their end_gas added to by
-							GAS_DIFFUSION_CONSTANT (at this writing, 0.125) times
-							this gas. So, 1.0 - (0.125 * adj_amount) = 0.625--
-							exactly the amount those gases "took" from this.
-						*/
-						{
-							let gas: &mut Mixture = &mut entry.write();
-							gas.multiply(1.0 - (*adj_amount as f32 * GAS_DIFFUSION_CONSTANT));
-							gas.merge(end_gas);
-						}
-						/*
-							If there is neither a major pressure difference
-							nor are there any visible gases nor does it need
-							to react, we're done outright. We don't need
-							to do any more and we don't need to send the
-							value to byond, so we don't. However, if we do...
-						*/
-						(*i, pressure_diffs, max_diff)
-					})
-				})
-				.partition(|&(_, _, max_diff)| max_diff <= 5.0);
-			//tossing things around is already handled by katmos, so we don't need to do it here.
-			if !equalize_enabled {
-				let pressure_deltas_chunked = high_pressure.par_chunks(20).collect::<Vec<_>>();
-				pressure_deltas_chunked
+	with_turf_gases_read(|arena| {
+		loop {
+			if cur_count > fdm_max_steps {
+				break;
+			}
+			GasArena::with_all_mixtures(|all_mixtures| {
+				let turfs_to_save = arena
+					/*
+						This directly yoinks the internal node vec
+						of the graph as a slice to parallelize the process.
+						The speedup gained from this is actually linear
+						with the amount of cores the CPU has, which, to be frank,
+						is way better than I was expecting, even though this operation
+						is technically embarassingly parallel. It'll probably reach
+						some maximum due to the global turf mixture lock access,
+						but it's already blazingly fast on my i7, so it should be fine.
+					*/
+					.graph
+					.raw_nodes()
 					.par_iter()
-					.with_min_len(5)
-					.for_each(|temp_value| {
-						let sender = byond_callback_sender();
-						let these_pressure_deltas = temp_value.to_vec();
-						drop(sender.try_send(Box::new(move || {
-							for &(turf_id, pressure_diffs, _) in
-								these_pressure_deltas.iter().filter(|&(id, _, _)| *id != 0)
+					.enumerate()
+					.filter_map(|(index, node)| Some((NodeIndex::from(index as u32), node.weight?)))
+					.filter(|(index, mixture)| {
+						should_process(*index, mixture, all_mixtures, &arena)
+					})
+					.filter_map(|(index, mixture)| {
+						process_cell(index, mixture, all_mixtures, &arena)
+					})
+					.collect::<Vec<_>>();
+				/*
+					For the optimization-heads reading this: this is not an unnecessary collect().
+					Saving all this to the turfs_to_save vector is, in fact, the reason
+					that gases don't need an archive anymore--this *is* the archival step,
+					simultaneously saving how the gases will change after the fact.
+					In short: the above actually needs to finish before the below starts
+					for consistency, so collect() is desired. This has been tested, by the way.
+				*/
+				let (low_pressure, high_pressure): (Vec<_>, Vec<_>) = turfs_to_save
+					.into_par_iter()
+					.filter_map(|(i, end_gas, mut pressure_diffs, adj_amount)| {
+						let m = arena.get(i).unwrap();
+						all_mixtures.get(m.mix).map(|entry| {
+							let mut max_diff = 0.0_f32;
+							let moved_pressure = {
+								let gas = entry.read();
+								gas.return_pressure() * GAS_DIFFUSION_CONSTANT
+							};
+							for pressure_diff in &mut pressure_diffs {
+								// pressure_diff.1 here was set to a negative above, so we just add.
+								pressure_diff.1 += moved_pressure;
+								max_diff = max_diff.max(pressure_diff.1.abs());
+							}
+							/*
+								1.0 - GAS_DIFFUSION_CONSTANT * adj_amount is going to be
+								precisely equal to the amount the surrounding tiles'
+								end_gas have "taken" from this tile--
+								they didn't actually take anything, just calculated
+								how much would be. This is the "taking" step.
+								Just to illustrate: say you have a turf with 3 neighbors.
+								Each of those neighbors will have their end_gas added to by
+								GAS_DIFFUSION_CONSTANT (at this writing, 0.125) times
+								this gas. So, 1.0 - (0.125 * adj_amount) = 0.625--
+								exactly the amount those gases "took" from this.
+							*/
 							{
-								let turf = unsafe { Value::turf_by_id_unchecked(turf_id) };
-								for &(id, diff) in &pressure_diffs {
-									if id != 0 {
-										let enemy_tile = unsafe { Value::turf_by_id_unchecked(id) };
-										if diff > 5.0 {
-											turf.call(
-												"consider_pressure_difference",
-												&[&enemy_tile, &Value::from(diff)],
-											)?;
-										} else if diff < -5.0 {
-											enemy_tile.call(
-												"consider_pressure_difference",
-												&[&turf.clone(), &Value::from(-diff)],
-											)?;
+								let gas: &mut Mixture = &mut entry.write();
+								gas.multiply(1.0 - (adj_amount as f32 * GAS_DIFFUSION_CONSTANT));
+								gas.merge(&end_gas);
+							}
+							/*
+								If there is neither a major pressure difference
+								nor are there any visible gases nor does it need
+								to react, we're done outright. We don't need
+								to do any more and we don't need to send the
+								value to byond, so we don't. However, if we do...
+							*/
+							(i, pressure_diffs, max_diff)
+						})
+					})
+					.partition(|&(_, _, max_diff)| max_diff <= 5.0);
+
+				high_pressure_turfs.par_extend(high_pressure.par_iter().map(|(i, _, _)| i));
+				low_pressure_turfs.par_extend(low_pressure.par_iter().map(|(i, _, _)| i));
+
+				//tossing things around is already handled by katmos, so we don't need to do it here.
+				if !equalize_enabled {
+					let pressure_deltas_fixed = high_pressure
+						.into_par_iter()
+						.filter_map(|(index, diffs, _)| Some((arena.get(index)?.id, diffs)))
+						.collect::<Vec<_>>();
+					let pressure_deltas_chunked =
+						pressure_deltas_fixed.par_chunks(20).collect::<Vec<_>>();
+					pressure_deltas_chunked
+						.par_iter()
+						.with_min_len(5)
+						.for_each(|temp_value| {
+							let sender = byond_callback_sender();
+							let these_pressure_deltas = temp_value.to_vec();
+							drop(sender.try_send(Box::new(move || {
+								for (turf_id, pressure_diffs) in
+									these_pressure_deltas.clone().into_iter()
+								{
+									let turf = unsafe { Value::turf_by_id_unchecked(turf_id) };
+									for (id, diff) in pressure_diffs {
+										if id != 0 {
+											let enemy_tile =
+												unsafe { Value::turf_by_id_unchecked(id) };
+											if diff > 5.0 {
+												turf.call(
+													"consider_pressure_difference",
+													&[&enemy_tile, &Value::from(diff)],
+												)?;
+											} else if diff < -5.0 {
+												enemy_tile.call(
+													"consider_pressure_difference",
+													&[&turf.clone(), &Value::from(-diff)],
+												)?;
+											}
 										}
 									}
 								}
-							}
-							Ok(Value::null())
-						})));
-					});
-			}
-			high_pressure_turfs.extend(high_pressure.iter().map(|(i, _, _)| i));
-			low_pressure_turfs.extend(low_pressure.iter().map(|(i, _, _)| i));
-		});
-		cur_count += 1;
-	}
+								Ok(Value::null())
+							})));
+						});
+				}
+			});
+			cur_count += 1;
+		}
+	});
 	(low_pressure_turfs, high_pressure_turfs)
 }
 
 // Finds small differences in turf pressures and equalizes them.
-fn excited_group_processing(
-	max_x: i32,
-	max_y: i32,
-	pressure_goal: f32,
-	low_pressure_turfs: &BTreeSet<TurfID>,
-) -> usize {
-	let mut found_turfs: BTreeSet<TurfID> = BTreeSet::new();
-	for &initial_turf in low_pressure_turfs {
-		if found_turfs.contains(&initial_turf) {
-			continue;
-		}
-		let initial_mix_ref = {
-			let maybe_initial_mix_ref = turf_gases().try_get(&initial_turf).try_unwrap();
-			if maybe_initial_mix_ref.is_none() {
-				continue;
-			}
-			*maybe_initial_mix_ref.unwrap()
-		};
-		let mut border_turfs: VecDeque<(TurfID, TurfMixture)> = VecDeque::with_capacity(40);
-		let mut turfs: Vec<TurfMixture> = Vec::with_capacity(200);
-		let mut min_pressure = initial_mix_ref.return_pressure();
-		let mut max_pressure = min_pressure;
-		let mut fully_mixed = Mixture::new();
-		border_turfs.push_back((initial_turf, initial_mix_ref));
-		found_turfs.insert(initial_turf);
+fn excited_group_processing(pressure_goal: f32, low_pressure_turfs: &Vec<NodeIndex>) -> usize {
+	let mut found_turfs: HashSet<NodeIndex, FxBuildHasher> = Default::default();
+	with_turf_gases_read(|arena| {
 		GasArena::with_all_mixtures(|all_mixtures| {
-			loop {
-				if turfs.len() >= 2500 {
-					break;
+			for &initial_turf in low_pressure_turfs {
+				if found_turfs.contains(&initial_turf) {
+					continue;
 				}
-				if let Some((i, turf)) = border_turfs.pop_front() {
-					let adj_tiles = adjacent_tile_ids(turf.adjacency, i, max_x, max_y);
-					if let Some(lock) = all_mixtures.get(turf.mix) {
-						let mix = lock.read();
-						let pressure = mix.return_pressure();
-						let this_max = max_pressure.max(pressure);
-						let this_min = min_pressure.min(pressure);
-						if (this_max - this_min).abs() >= pressure_goal {
-							continue;
-						}
-						min_pressure = this_min;
-						max_pressure = this_max;
-						turfs.push(turf);
-						fully_mixed.merge(&mix);
-						fully_mixed.volume += mix.volume;
-						for (_, loc) in adj_tiles {
-							if found_turfs.contains(&loc) {
+				let initial_mix_ref = {
+					let maybe_initial_mix_ref = arena.get(initial_turf);
+					if maybe_initial_mix_ref.is_none() {
+						continue;
+					}
+					*maybe_initial_mix_ref.unwrap()
+				};
+				let mut border_turfs: VecDeque<NodeIndex> = VecDeque::with_capacity(40);
+				let mut turfs: Vec<TurfMixture> = Vec::with_capacity(200);
+				let mut min_pressure = initial_mix_ref.return_pressure();
+				let mut max_pressure = min_pressure;
+				let mut fully_mixed = Mixture::new();
+				border_turfs.push_back(initial_turf);
+				found_turfs.insert(initial_turf);
+
+				loop {
+					if turfs.len() >= 2500 {
+						break;
+					}
+					if let Some(idx) = border_turfs.pop_front() {
+						let tmix = *arena.get(idx).unwrap();
+						if let Some(lock) = all_mixtures.get(tmix.mix) {
+							let mix = lock.read();
+							let pressure = mix.return_pressure();
+							let this_max = max_pressure.max(pressure);
+							let this_min = min_pressure.min(pressure);
+							if (this_max - this_min).abs() >= pressure_goal {
 								continue;
 							}
-							found_turfs.insert(loc);
-							if let Some(border_mix) = turf_gases()
-								.try_get(&loc)
-								.try_unwrap()
-								.filter(|b| b.enabled())
-							{
-								border_turfs.push_back((loc, *border_mix));
+							min_pressure = this_min;
+							max_pressure = this_max;
+							turfs.push(tmix);
+							fully_mixed.merge(&mix);
+							fully_mixed.volume += mix.volume;
+							for loc in arena.adjacent_node_ids(idx) {
+								if found_turfs.contains(&loc) {
+									continue;
+								}
+								found_turfs.insert(loc);
+								if arena.get(loc).filter(|b| b.enabled()).is_some() {
+									border_turfs.push_back(loc);
+								}
 							}
 						}
+					} else {
+						break;
 					}
-				} else {
-					break;
+				}
+				fully_mixed.multiply(1.0 / turfs.len() as f32);
+				if !fully_mixed.is_corrupt() {
+					turfs.par_iter().with_min_len(125).for_each(|turf| {
+						if let Some(mix_lock) = all_mixtures.get(turf.mix) {
+							mix_lock.write().copy_from_mutable(&fully_mixed);
+						}
+					});
 				}
 			}
-			fully_mixed.multiply(1.0 / turfs.len() as f32);
-			if !fully_mixed.is_corrupt() {
-				turfs.par_iter().with_min_len(125).for_each(|turf| {
-					if let Some(mix_lock) = all_mixtures.get(turf.mix) {
-						mix_lock.write().copy_from_mutable(&fully_mixed);
-					}
-				});
-			}
 		});
-	}
+	});
 	found_turfs.len()
 }
 
@@ -638,7 +638,7 @@ static mut PLANET_RESET_TIMER: Option<Instant> = None;
 
 // If this turf has planetary atmos, and it's sufficiently similar, just sets the turf's atmos to the planetary atmos.
 fn remove_trace_planet_gases(
-	m: TurfMixture,
+	m: &TurfMixture,
 	planetary_atmos: &'static DashMap<u32, Mixture, FxBuildHasher>,
 	all_mixtures: &[RwLock<Mixture>],
 ) {
@@ -663,27 +663,28 @@ static mut VISUALS_CACHE: Option<std::collections::HashMap<usize, u64, FxBuildHa
 
 // Checks if the gas can react or can update visuals, returns None if not.
 fn post_process_cell(
-	i: TurfID,
-	m: TurfMixture,
+	mixture: &TurfMixture,
 	vis: &[Option<f32>],
 	all_mixtures: &[RwLock<Mixture>],
 	vis_cache: &std::collections::HashMap<usize, u64, FxBuildHasher>,
 	updates: &flume::Sender<(usize, u64)>,
 ) -> Option<(TurfID, bool, bool)> {
 	all_mixtures
-		.get(m.mix)
+		.get(mixture.mix)
 		.and_then(RwLock::try_read)
 		.and_then(|gas| {
-			let should_update_visuals =
-				match gas.vis_hash_changed(vis, vis_cache.get(&m.mix).copied().unwrap_or(0)) {
-					Some(hash) => {
-						let _ = updates.send((m.mix, hash));
-						true
-					}
-					None => false,
-				};
+			let should_update_visuals = match gas
+				.vis_hash_changed(vis, vis_cache.get(&mixture.mix).copied().unwrap_or(0))
+			{
+				Some(hash) => {
+					let _ = updates.send((mixture.mix, hash));
+					true
+				}
+				None => false,
+			};
 			let reactable = gas.can_react();
-			(should_update_visuals || reactable).then(|| (i, should_update_visuals, reactable))
+			(should_update_visuals || reactable)
+				.then(|| (mixture.id, should_update_visuals, reactable))
 		})
 }
 
@@ -706,26 +707,38 @@ fn post_process() {
 			.get_or_insert_with(|| std::collections::HashMap::with_hasher(FxBuildHasher::default()))
 	};
 	let processables = {
-		turf_gases()
-			.par_iter()
-			.map(|entry| {
-				let (&i, &m) = entry.pair();
-				(i, m)
-			})
-			.filter_map(|(i, m)| {
-				m.enabled()
-					.then(|| {
-						GasArena::with_all_mixtures(|all_mixtures| {
-							if should_check_planet_turfs {
-								let planetary_atmos = planetary_atmos();
-								remove_trace_planet_gases(m, planetary_atmos, all_mixtures);
-							}
-							post_process_cell(i, m, &vis, all_mixtures, vis_cache, &sender.clone())
+		with_turf_gases_read(|arena| {
+			arena
+				.graph
+				.raw_nodes()
+				.par_iter()
+				.filter_map(|node| node.weight)
+				.filter_map(|mixture| {
+					mixture
+						.enabled()
+						.then(|| {
+							GasArena::with_all_mixtures(|all_mixtures| {
+								if should_check_planet_turfs {
+									let planetary_atmos = planetary_atmos();
+									remove_trace_planet_gases(
+										&mixture,
+										planetary_atmos,
+										all_mixtures,
+									);
+								}
+								post_process_cell(
+									&mixture,
+									&vis,
+									all_mixtures,
+									vis_cache,
+									&sender.clone(),
+								)
+							})
 						})
-					})
-					.flatten()
-			})
-			.collect::<Vec<_>>()
+						.flatten()
+				})
+				.collect::<Vec<_>>()
+		})
 	};
 	processables.into_par_iter().chunks(30).for_each(|chunk| {
 		let sender = byond_callback_sender();
@@ -741,7 +754,7 @@ fn post_process() {
 				}
 				if should_update_vis {
 					//turf.call("update_visuals", &[])?;
-					update_visuals(&turf)?;
+					update_visuals(turf)?;
 				}
 			}
 			Ok(Value::null())
@@ -773,7 +786,6 @@ fn _process_heat_notify() {
 		between turfs and their gases. Since the latter requires a write lock,
 		it's done after the previous step. This one doesn't care about
 		consistency like the processing step does--this can run in full parallel.
-
 		Can't get a number from src in the thread, so we get it here.
 		Have to get the time delta because the radiation
 		is actually physics-based--the stefan boltzmann constant
@@ -828,126 +840,128 @@ fn _process_heat_start() -> Result<(), String> {
 		rayon::spawn(|| loop {
 			//this will block until process_turf_heat is called
 			let info = with_heat_processing_callback_receiver(|receiver| receiver.recv().unwrap());
-			TASKS_RUNNING.fetch_add(1, Ordering::SeqCst);
+			TASKS_RUNNING.fetch_add(1, Ordering::Acquire);
 			let start_time = Instant::now();
 			let sender = byond_callback_sender();
 			let emissivity_constant: f64 = STEFAN_BOLTZMANN_CONSTANT * info.time_delta;
 			let radiation_from_space_tick: f64 = RADIATION_FROM_SPACE * info.time_delta;
-			let temps_to_update = turf_temperatures()
-				.par_iter()
-				.map(|entry| {
-					let (&i, &t) = entry.pair();
-					(i, t)
-				})
-				.filter_map(|(i, t)| {
-					let adj = t.adjacency;
-					/*
-						If it has no thermal conductivity or low thermal capacity,
-						then it's not gonna interact, or at least shouldn't.
-					*/
-					(t.thermal_conductivity > 0.0 && t.heat_capacity > 0.0 && adj > 0)
-						.then(|| {
-							let mut heat_delta = 0.0;
-							let is_temp_delta_with_air = turf_gases()
-								.try_get(&i)
-								.try_unwrap()
-								.filter(|m| m.enabled())
-								.and_then(|m| {
-									GasArena::with_all_mixtures(|all_mixtures| {
-										all_mixtures.get(m.mix).and_then(RwLock::try_read).map(
-											|gas| (t.temperature - gas.get_temperature() > 1.0),
+			with_turf_gases_read(|arena| {
+				let temps_to_update = turf_temperatures()
+					.par_iter()
+					.map(|entry| {
+						let (&i, &t) = entry.pair();
+						(i, t)
+					})
+					.filter_map(|(i, t)| {
+						let adj = t.adjacency;
+						/*
+							If it has no thermal conductivity or low thermal capacity,
+							then it's not gonna interact, or at least shouldn't.
+						*/
+						(t.thermal_conductivity > 0.0 && t.heat_capacity > 0.0 && adj > 0)
+							.then(|| {
+								let mut heat_delta = 0.0;
+								let is_temp_delta_with_air = arena
+									.get_from_turfid(&i)
+									.filter(|m| m.enabled())
+									.and_then(|m| {
+										GasArena::with_all_mixtures(|all_mixtures| {
+											all_mixtures.get(m.mix).and_then(RwLock::try_read).map(
+												|gas| (t.temperature - gas.get_temperature() > 1.0),
+											)
+										})
+									})
+									.unwrap_or(false);
+
+								for (_, loc) in adjacent_tile_ids(adj, i, info.max_x, info.max_y) {
+									heat_delta += turf_temperatures()
+										.try_get(&loc)
+										.try_unwrap()
+										.map_or(0.0, |other| {
+											/*
+												The horrible line below is essentially
+												sharing between solids--making it the minimum of both
+												conductivities makes this consistent, funnily enough.
+											*/
+											t.thermal_conductivity.min(other.thermal_conductivity)
+												* (other.temperature - t.temperature) * (t
+												.heat_capacity
+												* other.heat_capacity
+												/ (t.heat_capacity + other.heat_capacity))
+										});
+								}
+								if t.adjacent_to_space {
+									/*
+										Straight up the standard blackbody radiation
+										equation. All these are f64s because
+										f32::MAX^4 < f64::MAX, and t.temperature
+										is ordinarily an f32, meaning that
+										this will never go into infinities.
+									*/
+									let blackbody_radiation: f64 = (emissivity_constant
+										* (f64::from(t.temperature).powi(4)))
+										- radiation_from_space_tick;
+									heat_delta -= blackbody_radiation as f32;
+								}
+								let temp_delta = heat_delta / t.heat_capacity;
+								(is_temp_delta_with_air || temp_delta.abs() > 0.01)
+									.then(|| (i, t.temperature + temp_delta))
+							})
+							.flatten()
+					})
+					.collect::<Vec<_>>();
+				temps_to_update
+					.par_iter()
+					.with_min_len(100)
+					.for_each(|&(i, new_temp)| {
+						let maybe_t = turf_temperatures().try_get_mut(&i).try_unwrap();
+						if maybe_t.is_none() {
+							return;
+						}
+						let t: &mut ThermalInfo = &mut maybe_t.unwrap();
+						t.temperature = arena
+							.get_from_turfid(&i)
+							.filter(|m| m.enabled())
+							.and_then(|m| {
+								GasArena::with_all_mixtures(|all_mixtures| {
+									all_mixtures.get(m.mix).map(|entry| {
+										let gas: &mut Mixture = &mut entry.write();
+										gas.temperature_share_non_gas(
+											/*
+												This value should be lower than the
+												turf-to-turf conductivity for balance reasons
+												as well as realism, otherwise fires will
+												just sort of solve theirselves over time.
+											*/
+											t.thermal_conductivity * OPEN_HEAT_TRANSFER_COEFFICIENT,
+											new_temp,
+											t.heat_capacity,
 										)
 									})
 								})
-								.unwrap_or(false);
-							for (_, loc) in adjacent_tile_ids(adj, i, info.max_x, info.max_y) {
-								heat_delta += turf_temperatures()
-									.try_get(&loc)
-									.try_unwrap()
-									.map_or(0.0, |other| {
-										/*
-											The horrible line below is essentially
-											sharing between solids--making it the minimum of both
-											conductivities makes this consistent, funnily enough.
-										*/
-										t.thermal_conductivity.min(other.thermal_conductivity)
-											* (other.temperature - t.temperature) * (t.heat_capacity
-											* other.heat_capacity
-											/ (t.heat_capacity + other.heat_capacity))
-									});
-							}
-							if t.adjacent_to_space {
-								/*
-									Straight up the standard blackbody radiation
-									equation. All these are f64s because
-									f32::MAX^4 < f64::MAX, and t.temperature
-									is ordinarily an f32, meaning that
-									this will never go into infinities.
-								*/
-								let blackbody_radiation: f64 = (emissivity_constant
-									* (f64::from(t.temperature).powi(4)))
-									- radiation_from_space_tick;
-								heat_delta -= blackbody_radiation as f32;
-							}
-							let temp_delta = heat_delta / t.heat_capacity;
-							(is_temp_delta_with_air || temp_delta.abs() > 0.01)
-								.then(|| (i, t.temperature + temp_delta))
-						})
-						.flatten()
-				})
-				.collect::<Vec<_>>();
-			temps_to_update
-				.par_iter()
-				.with_min_len(100)
-				.for_each(|&(i, new_temp)| {
-					let maybe_t = turf_temperatures().try_get_mut(&i).try_unwrap();
-					if maybe_t.is_none() {
-						return;
-					}
-					let t: &mut ThermalInfo = &mut maybe_t.unwrap();
-					t.temperature = turf_gases()
-						.try_get(&i)
-						.try_unwrap()
-						.filter(|m| m.enabled())
-						.and_then(|m| {
-							GasArena::with_all_mixtures(|all_mixtures| {
-								all_mixtures.get(m.mix).map(|entry| {
-									let gas: &mut Mixture = &mut entry.write();
-									gas.temperature_share_non_gas(
-										/*
-											This value should be lower than the
-											turf-to-turf conductivity for balance reasons
-											as well as realism, otherwise fires will
-											just sort of solve theirselves over time.
-										*/
-										t.thermal_conductivity * OPEN_HEAT_TRANSFER_COEFFICIENT,
-										new_temp,
-										t.heat_capacity,
-									)
-								})
 							})
-						})
-						.unwrap_or(new_temp);
-					if !t.temperature.is_normal() {
-						t.temperature = 2.7;
-					}
-					if t.temperature > MINIMUM_TEMPERATURE_START_SUPERCONDUCTION
-						&& t.temperature > t.heat_capacity
-					{
-						// not what heat capacity means but whatever
-						drop(sender.try_send(Box::new(move || {
-							let turf = unsafe { Value::turf_by_id_unchecked(i) };
-							turf.set(byond_string!("to_be_destroyed"), 1.0)?;
-							Ok(Value::null())
-						})));
-					}
-				});
+							.unwrap_or(new_temp);
+						if !t.temperature.is_normal() {
+							t.temperature = 2.7;
+						}
+						if t.temperature > MINIMUM_TEMPERATURE_START_SUPERCONDUCTION
+							&& t.temperature > t.heat_capacity
+						{
+							// not what heat capacity means but whatever
+							drop(sender.try_send(Box::new(move || {
+								let turf = unsafe { Value::turf_by_id_unchecked(i) };
+								turf.set(byond_string!("to_be_destroyed"), 1.0)?;
+								Ok(Value::null())
+							})));
+						}
+					});
+			});
 			//Alright, now how much time did that take?
 			let bench = start_time.elapsed().as_nanos();
-			let old_bench = HEAT_PROCESS_TIME.load(Ordering::SeqCst);
+			let old_bench = HEAT_PROCESS_TIME.load(Ordering::Acquire);
 			// We display this as part of the MC atmospherics stuff.
-			HEAT_PROCESS_TIME.store((old_bench * 3 + (bench * 7) as u64) / 10, Ordering::SeqCst);
-			TASKS_RUNNING.fetch_sub(1, Ordering::SeqCst);
+			HEAT_PROCESS_TIME.store((old_bench * 3 + (bench * 7) as u64) / 10, Ordering::Release);
+			TASKS_RUNNING.fetch_sub(1, Ordering::Release);
 		});
 	});
 	Ok(())


### PR DESCRIPTION
Replaces the adjacency dashmap with a graph backed by a hashmap. This means fdm/katmos can support an arbitrary number of adjacencies on one turf and does not rely on turfID manipulations. Makes gas portals and similar shenanigans possible.

Iterating over the raw slice of the graph is actually stupidly fast, faster than the dashmap even.

Issues: 
- Katmos no longer closes firedoors anymore, and needs figuring out
- monstermos/putnamos doesn't work at all now

