### PR TITLE
Redo katmos a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -184,15 +184,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
@@ -208,12 +208,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.12.1",
+ "hashbrown",
  "lock_api",
  "parking_lot_core",
  "rayon",
@@ -368,12 +368,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
@@ -395,12 +389,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
  "rayon",
 ]
 
@@ -610,18 +604,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -700,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -43,7 +43,7 @@ fn is_registered_mix(i: u32) -> bool {
 fn register_mix(v: &Value) {
 	unsafe {
 		REGISTERED_GAS_MIXES
-			.get_or_insert_with(|| HashSet::with_hasher(FxBuildHasher::default()))
+			.get_or_insert_with(|| Default::default())
 			.insert(v.raw.data.id);
 	}
 }
@@ -51,7 +51,7 @@ fn register_mix(v: &Value) {
 fn unregister_mix(i: u32) {
 	unsafe {
 		REGISTERED_GAS_MIXES
-			.get_or_insert_with(|| HashSet::with_hasher(FxBuildHasher::default()))
+			.get_or_insert_with(|| Default::default())
 			.remove(&i);
 	}
 }
@@ -69,7 +69,7 @@ fn _shut_down_gases() {
 	NEXT_GAS_IDS.write().as_mut().unwrap().clear();
 	unsafe {
 		REGISTERED_GAS_MIXES
-			.get_or_insert_with(|| HashSet::with_hasher(FxBuildHasher::default()))
+			.get_or_insert_with(|| Default::default())
 			.clear();
 	}
 }

--- a/src/gas/mixture.rs
+++ b/src/gas/mixture.rs
@@ -581,9 +581,11 @@ impl Mixture {
 		hash_holder: &AtomicU64,
 	) -> bool {
 		let cur_hash = self.vis_hash(gas_visibility);
-		hash_holder.fetch_update(Relaxed, Relaxed, |item| {
-            (item != cur_hash).then(|| cur_hash)
-        }).is_ok()
+		hash_holder
+			.fetch_update(Relaxed, Relaxed, |item| {
+				(item != cur_hash).then(|| cur_hash)
+			})
+			.is_ok()
 	}
 	// Removes all redundant zeroes from the gas mixture.
 	pub fn garbage_collect(&mut self) {

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -27,6 +27,7 @@ use rayon::prelude::*;
 
 use std::collections::HashMap;
 use std::mem::drop;
+use std::sync::atomic::AtomicU64;
 
 use crate::callbacks::aux_callbacks_sender;
 
@@ -89,13 +90,13 @@ const fn adj_flag_to_idx(adj_flag: Directions) -> usize {
 type TurfID = u32;
 
 // TurfMixture can be treated as "immutable" for all intents and purposes--put other data somewhere else
-#[derive(Clone, Copy, Default, Hash, Eq, PartialEq)]
+#[derive(Default)]
 struct TurfMixture {
 	pub mix: usize,
 	pub id: TurfID,
 	pub flags: SimulationFlags,
 	pub planetary_atmos: Option<u32>,
-	pub num_neighbors: u8,
+	pub vis_hash: AtomicU64,
 }
 
 #[allow(dead_code)]

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -174,13 +174,7 @@ fn finalize_eq_neighbors(
 	for adj_index in arena.adjacent_node_ids(index) {
 		let amount = *transfer_dirs.get(&Some(adj_index)).unwrap_or(&0.0);
 		if amount < 0.0 {
-			finalize_eq(
-				adj_index,
-				arena,
-				info,
-				eq_movement_graph,
-				pressures,
-			);
+			finalize_eq(adj_index, arena, info, eq_movement_graph, pressures);
 		}
 	}
 }
@@ -478,9 +472,7 @@ fn explosively_depressurize(
 				if let Some(adj_mixture) = arena.get(adj_index) {
 					let adj_orig = info.entry(adj_index).or_default();
 					let mut adj_info = adj_orig.get();
-					if !adj_mixture.is_immutable()
-						&& progression_order.insert(adj_index)
-					{
+					if !adj_mixture.is_immutable() && progression_order.insert(adj_index) {
 						adj_info.curr_transfer_dir = Some(cur_index);
 						adj_info.curr_transfer_amount = 0.0;
 						let cur_target_turf =
@@ -605,8 +597,7 @@ fn flood_fill_equalize_turfs(
 	f64,
 )> {
 	let mut turfs: IndexSet<NodeIndex<usize>, FxBuildHasher> = Default::default();
-	let mut border_turfs: std::collections::VecDeque<NodeIndex<usize>> =
-		Default::default();
+	let mut border_turfs: std::collections::VecDeque<NodeIndex<usize>> = Default::default();
 	let mut planet_turfs: IndexSet<NodeIndex<usize>, FxBuildHasher> = Default::default();
 	let sender = byond_callback_sender();
 	let mut total_moles = 0.0_f64;
@@ -676,8 +667,7 @@ fn process_planet_turfs(
 	let planet_sum = maybe_planet_sum.unwrap().value().total_moles();
 	let target_delta = planet_sum - average_moles;
 
-	let mut progression_order: IndexSet<NodeIndex<usize>, FxBuildHasher> =
-		Default::default();
+	let mut progression_order: IndexSet<NodeIndex<usize>, FxBuildHasher> = Default::default();
 
 	for &cur_index in planet_turfs {
 		progression_order.insert(cur_index);
@@ -712,10 +702,7 @@ fn process_planet_turfs(
 						Ok(Value::null())
 					}));
 				}
-				if arena
-					.get(adj_index)
-					.map_or(false, |terf| terf.enabled())
-				{
+				if arena.get(adj_index).map_or(false, |terf| terf.enabled()) {
 					if !progression_order.insert(adj_index) {
 						continue;
 					}
@@ -889,13 +876,7 @@ pub(crate) fn equalize(
 		turfs.into_par_iter().for_each(|(turf, info, mut graph)| {
 			let mut pressures: Vec<(f32, u32, u32)> = Vec::new();
 			turf.iter().for_each(|&cur_index| {
-				finalize_eq(
-					cur_index,
-					&arena,
-					&info,
-					&mut graph,
-					&mut pressures,
-				);
+				finalize_eq(cur_index, &arena, &info, &mut graph, &mut pressures);
 			});
 
 			pressures.par_chunks(20).for_each(|chunk| {

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -780,7 +780,7 @@ pub(crate) fn equalize(
 			.collect::<Vec<_>>();
 
 		if check_turfs_dirty() {
-			return
+			return;
 		}
 
 		let did_firelocks = {
@@ -862,7 +862,7 @@ pub(crate) fn equalize(
 			.collect::<Vec<_>>();
 
 		if check_turfs_dirty() {
-			return
+			return;
 		}
 
 		turfs.into_par_iter().for_each(|(turf, mut graph)| {

--- a/src/turfs/katmos.rs
+++ b/src/turfs/katmos.rs
@@ -779,6 +779,10 @@ pub(crate) fn equalize(
 			})
 			.collect::<Vec<_>>();
 
+		if check_turfs_dirty() {
+			return
+		}
+
 		let did_firelocks = {
 			if contains_planet.load(Ordering::Acquire) {
 				PLANET_TURF_CYCLE.fetch_xor(true, Ordering::Relaxed)
@@ -856,6 +860,10 @@ pub(crate) fn equalize(
 				(turfs, graph)
 			})
 			.collect::<Vec<_>>();
+
+		if check_turfs_dirty() {
+			return
+		}
 
 		turfs.into_par_iter().for_each(|(turf, mut graph)| {
 			let mut pressures: Vec<(f32, u32, u32)> = Vec::new();

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque, BTreeSet};
+use std::collections::{BTreeSet, HashSet, VecDeque};
 
 use auxtools::*;
 
@@ -90,9 +90,9 @@ fn _finish_process_turfs() {
 			)
 		})?;
 	let processing_callbacks_unfinished = process_callbacks_for_millis(arg_limit as u64);
-    if TASKS_RUNNING.load(Ordering::Relaxed) == 0 {
-        rebuild_turf_graph()?;
-    }
+	if TASKS_RUNNING.load(Ordering::Relaxed) == 0 {
+		rebuild_turf_graph()?;
+	}
 	if processing_callbacks_unfinished {
 		Ok(Value::from(true))
 	} else {
@@ -321,7 +321,7 @@ fn _process_turf_start() -> Result<(), String> {
 					Ok(Value::null())
 				})));
 			}
-    		{
+			{
 				//let it gooooo
 				rayon::spawn(|| planet_process());
 			}
@@ -464,10 +464,7 @@ fn process_cell(
 fn fdm(
 	fdm_max_steps: i32,
 	equalize_enabled: bool,
-) -> (
-	BTreeSet<NodeIndex<usize>>,
-	BTreeSet<NodeIndex<usize>>,
-) {
+) -> (BTreeSet<NodeIndex<usize>>, BTreeSet<NodeIndex<usize>>) {
 	/*
 		This is the replacement system for LINDA. LINDA requires a lot of bookkeeping,
 		which, when coefficient-wise operations are this fast, is all just unnecessary overhead.
@@ -495,7 +492,7 @@ fn fdm(
 						some maximum due to the global turf mixture lock access,
 						but it's already blazingly fast on my i7, so it should be fine.
 					*/
-                    .par_values()
+					.par_values()
 					.map(|&idx| (idx, arena.get(idx).unwrap()))
 					.filter(|(index, mixture)| should_process(*index, mixture, all_mixtures, arena))
 					.filter_map(|(index, _)| process_cell(index, all_mixtures, arena))
@@ -696,7 +693,7 @@ fn post_process() {
 			GasArena::with_all_mixtures(|all_mixtures| {
 				arena
 					.map
-                    .par_values()
+					.par_values()
 					.filter_map(|&node_index| {
 						let mix = arena.get(node_index).unwrap();
 						mix.enabled().then(|| mix)

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -42,8 +42,6 @@ struct SSairInfo {
 	equalize_hard_turf_limit: usize,
 	equalize_enabled: bool,
 	group_pressure_goal: f32,
-	max_x: i32,
-	max_y: i32,
 	planet_enabled: bool,
 }
 
@@ -109,7 +107,7 @@ pub(crate) fn rebuild_turf_graph() -> Result<(), Runtime> {
 			register_turf(t)?;
 		}
 		for (t, flags) in dirty_turfs
-			.drain()
+			.drain(..)
 			.filter(|&(_, flags)| flags.contains(DirtyFlags::DIRTY_ADJACENT))
 		{
 			update_adjacency_info(t, flags.contains(DirtyFlags::DIRTY_ADJACENT_TO_SPACE))?
@@ -145,26 +143,6 @@ fn _process_turf_notify() {
 	let group_pressure_goal = src
 		.get_number(byond_string!("excited_group_pressure_goal"))
 		.unwrap_or(0.5);
-	let max_x = auxtools::Value::world()
-		.get_number(byond_string!("maxx"))
-		.map_err(|_| {
-			runtime!(
-				"Attempt to interpret non-number value as number {} {}:{}",
-				std::file!(),
-				std::line!(),
-				std::column!()
-			)
-		})? as i32;
-	let max_y = auxtools::Value::world()
-		.get_number(byond_string!("maxy"))
-		.map_err(|_| {
-			runtime!(
-				"Attempt to interpret non-number value as number {} {}:{}",
-				std::file!(),
-				std::line!(),
-				std::column!()
-			)
-		})? as i32;
 	let planet_enabled: bool = src
 		.get_number(byond_string!("planet_equalize_enabled"))
 		.unwrap_or(1.0)
@@ -175,8 +153,6 @@ fn _process_turf_notify() {
 		equalize_hard_turf_limit,
 		equalize_enabled,
 		group_pressure_goal,
-		max_x,
-		max_y,
 		planet_enabled,
 	})));
 	Ok(Value::null())

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -724,9 +724,7 @@ fn post_process_cell(
 		.get(mixture.mix)
 		.and_then(RwLock::try_read)
 		.and_then(|gas| {
-			let should_update_visuals = gas.vis_hash_changed(
-				vis,
-				&mixture.vis_hash);
+			let should_update_visuals = gas.vis_hash_changed(vis, &mixture.vis_hash);
 			let reactable = gas.can_react_with_slice(reactions);
 			(should_update_visuals || reactable)
 				.then(|| (mixture.id, should_update_visuals, reactable))
@@ -745,12 +743,7 @@ fn post_process(nodes: &[NodeIndex<usize>]) {
 					.par_iter()
 					.filter_map(|&node| {
 						let mixture = arena.get(node)?;
-						post_process_cell(
-							&mixture,
-							&vis,
-							all_mixtures,
-							&reactions,
-						)
+						post_process_cell(&mixture, &vis, all_mixtures, &reactions)
 					})
 					.collect::<Vec<_>>()
 			})
@@ -761,12 +754,7 @@ fn post_process(nodes: &[NodeIndex<usize>]) {
 						.par_iter()
 						.filter_map(|&node| {
 							let mixture = arena.get(node)?;
-							post_process_cell(
-								&mixture,
-								&vis,
-								all_mixtures,
-								&reactions,
-							)
+							post_process_cell(&mixture, &vis, all_mixtures, &reactions)
 						})
 						.collect::<Vec<_>>()
 				})

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -224,7 +224,7 @@ fn _process_turf_start() -> Result<(), String> {
 				}));
 				(low_pressure_turfs, high_pressure_turfs)
 			};
-			if !check_turfs_dirty() {
+			{
 				let start_time = Instant::now();
 				let processed_turfs =
 					excited_group_processing(info.group_pressure_goal, &low_pressure_turfs);
@@ -253,7 +253,7 @@ fn _process_turf_start() -> Result<(), String> {
 					Ok(Value::null())
 				}));
 			}
-			if info.equalize_enabled && !check_turfs_dirty() {
+			if info.equalize_enabled {
 				let start_time = Instant::now();
 				let processed_turfs = {
 					#[cfg(feature = "fastmos")]
@@ -476,7 +476,7 @@ fn fdm(
 	let mut cur_count = 1;
 	with_turf_gases_read(|arena| {
 		loop {
-			if cur_count > fdm_max_steps {
+			if cur_count > fdm_max_steps || check_turfs_dirty() {
 				break;
 			}
 			GasArena::with_all_mixtures(|all_mixtures| {
@@ -620,7 +620,7 @@ fn excited_group_processing(
 			found_turfs.insert(initial_turf);
 			GasArena::with_all_mixtures(|all_mixtures| {
 				loop {
-					if turfs.len() >= 2500 {
+					if turfs.len() >= 2500 || check_turfs_dirty() {
 						break;
 					}
 					if let Some(idx) = border_turfs.pop_front() {


### PR DESCRIPTION
now it knows it's already in a floodfilled area

- vishashes is now stored as an atomic inside TurfMixture
- vishashes now represent vis updates more accurately, reducing unecessary updates by alot
- no more scc, back to the old par iter
- turfarena is back to using stablegraph, for less itering?????, less memory usage???
- turfarena map is now an indexmap, because that's faster for some reason
