### PR TITLE
Remove the check for duplicate IDs

### DIFF
--- a/crates/auxmos/src/reaction.rs
+++ b/crates/auxmos/src/reaction.rs
@@ -127,12 +127,6 @@ impl Reaction {
 
 		REACTION_VALUES.with(|r| -> Result<(), Runtime> {
 			let mut reaction_map = r.borrow_mut();
-			if reaction_map.contains_key(&our_reaction.id) {
-				return Err(runtime!(format!(
-					"Duplicate reaction id {}, only one reaction of this id will be registered",
-					string_id
-				)));
-			}
 			match func {
 				Some(function) => {
 					reaction_map.insert(our_reaction.id, ReactionSide::RustSide(function))


### PR DESCRIPTION
It's making any runtime reactions kill all reactions due to the way the reactions list is built, which isn't ideal.