### PR TITLE
Downgrade release/build runner Ubuntu to 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 jobs:
   linux-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
As discussed in coderbus; `ubuntu-latest` was automatically updated to 22.04 from 20.04, putting it out of sync with most SS13 CI actions, which are pinned to `ubuntu-20.04`. This brings it back into parity by downgrading to Ubuntu 20.04 LTS.

Also, the separate Linux build step can probably be removed since build-and-release exists, but I'm not doing that in this PR.