### PR TITLE
Sanity check for null air turfs trying to update visuals

### DIFF
--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -533,14 +533,16 @@ fn update_visuals(src: ByondValue) -> Result<ByondValue> {
 			// gas_overlays: list( GAS_ID = list( VIS_FACTORS = OVERLAYS )) got it? I don't
 			let gas_overlays = ByondValue::new_global_ref()
 				.read_var_id(byond_string!("GLOB"))
-				.wrap_err("GLOB is null")?
+				.wrap_err("Unable to get GLOB from BYOND globals")?
 				.read_var_id(byond_string!("gas_data"))
-				.wrap_err("gas_data is null")?
+				.wrap_err("gas_data is undefined on GLOB")?
 				.read_var_id(byond_string!("overlays"))
-				.wrap_err("overlays is null")?;
+				.wrap_err("overlays is undefined in GLOB.gas_data")?;
 			let ptr = air
-				.read_number_id(byond_string!("_extools_pointer_gasmixture"))
-				.wrap_err("Gas mixture doesn't have a valid pointer")? as usize;
+				.read_var_id(byond_string!("_extools_pointer_gasmixture"))
+				.wrap_err("air is undefined on turf")?
+				.get_number()
+				.wrap_err("Gas mixture has invalid pointer")? as usize;
 			let overlay_types = GasArena::with_gas_mixture(ptr, |mix| {
 				Ok(mix
 					.enumerate()

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -568,14 +568,14 @@ fn update_visuals(src: ByondValue) -> Result<ByondValue> {
 					byond_string!("set_visuals"),
 					&[overlay_types.as_slice().try_into()?],
 				)
-				.wrap_err("Calling set_visuals"))
+				.wrap_err("Calling set_visuals")?)
 		}
-		// If air is not defined or is null, just call set_visuals with no args
-		_ => {
-			return Ok(src
-				.call_id(byond_string!("set_visuals"), &[])
-				.wrap_err("Calling set_visuals with no args"));
-		}
+		// If air is null, clear the visuals
+		Ok(_) => Ok(src
+			.call_id(byond_string!("set_visuals"), &[])
+			.wrap_err("Calling set_visuals with no args")?),
+		// If air is not defined, it must be a closed turf. Do .othing
+		Err(_) => Ok(ByondValue::null()),
 	}
 }
 

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -525,48 +525,58 @@ fn hook_infos(src: ByondValue) -> Result<ByondValue> {
 /// Will use a cached overlay list if one exists.
 /// # Errors
 /// If auxgm wasn't implemented properly or there's an invalid gas mixture.
-fn update_visuals(src: ByondValue, air: ByondValue) -> Result<ByondValue> {
+fn update_visuals(src: ByondValue) -> Result<ByondValue> {
 	use super::gas;
-	// gas_overlays: list( GAS_ID = list( VIS_FACTORS = OVERLAYS )) got it? I don't
-	let gas_overlays = ByondValue::new_global_ref()
-		.read_var_id(byond_string!("GLOB"))
-		.wrap_err("Unable to get GLOB from BYOND globals")?
-		.read_var_id(byond_string!("gas_data"))
-		.wrap_err("gas_data is undefined on GLOB")?
-		.read_var_id(byond_string!("overlays"))
-		.wrap_err("overlays is undefined in GLOB.gas_data")?;
-	let ptr = air
-		.read_var_id(byond_string!("_extools_pointer_gasmixture"))
-		.wrap_err("air is undefined on turf")?
-		.get_number()
-		.wrap_err("Gas mixture has invalid pointer")? as usize;
-	let overlay_types = GasArena::with_gas_mixture(ptr, |mix| {
-		Ok(mix
-			.enumerate()
-			.filter_map(|(idx, moles)| Some((idx, moles, gas::types::gas_visibility(idx)?)))
-			.filter(|(_, moles, amt)| moles > amt)
-			// getting the list(VIS_FACTORS = OVERLAYS) with GAS_ID
-			.filter_map(|(idx, moles, _)| {
-				Some((
-					gas_overlays.read_list_index(gas::gas_idx_to_id(idx)).ok()?,
-					moles,
-				))
-			})
-			// getting the OVERLAYS with VIS_FACTOR
-			.filter_map(|(this_overlay_list, moles)| {
-				this_overlay_list
-					.read_list_index(gas::mixture::visibility_step(moles) as f32)
-					.ok()
-			})
-			.collect::<Vec<_>>())
-	})?;
+	match src.read_var_id(byond_string!("air")) {
+		Ok(air) if !air.is_null() => {
+			// gas_overlays: list( GAS_ID = list( VIS_FACTORS = OVERLAYS )) got it? I don't
+			let gas_overlays = ByondValue::new_global_ref()
+				.read_var_id(byond_string!("GLOB"))
+				.wrap_err("Unable to get GLOB from BYOND globals")?
+				.read_var_id(byond_string!("gas_data"))
+				.wrap_err("gas_data is undefined on GLOB")?
+				.read_var_id(byond_string!("overlays"))
+				.wrap_err("overlays is undefined in GLOB.gas_data")?;
+			let ptr = air
+				.read_var_id(byond_string!("_extools_pointer_gasmixture"))
+				.wrap_err("air is undefined on turf")?
+				.get_number()
+				.wrap_err("Gas mixture has invalid pointer")? as usize;
+			let overlay_types = GasArena::with_gas_mixture(ptr, |mix| {
+				Ok(mix
+					.enumerate()
+					.filter_map(|(idx, moles)| Some((idx, moles, gas::types::gas_visibility(idx)?)))
+					.filter(|(_, moles, amt)| moles > amt)
+					// getting the list(VIS_FACTORS = OVERLAYS) with GAS_ID
+					.filter_map(|(idx, moles, _)| {
+						Some((
+							gas_overlays.read_list_index(gas::gas_idx_to_id(idx)).ok()?,
+							moles,
+						))
+					})
+					// getting the OVERLAYS with VIS_FACTOR
+					.filter_map(|(this_overlay_list, moles)| {
+						this_overlay_list
+							.read_list_index(gas::mixture::visibility_step(moles) as f32)
+							.ok()
+					})
+					.collect::<Vec<_>>())
+			})?;
 
-	Ok(src
-		.call_id(
-			byond_string!("set_visuals"),
-			&[overlay_types.as_slice().try_into()?],
-		)
-		.wrap_err("Calling set_visuals")?)
+			Ok(src
+				.call_id(
+					byond_string!("set_visuals"),
+					&[overlay_types.as_slice().try_into()?],
+				)
+				.wrap_err("Calling set_visuals")?)
+		}
+		// If air is not defined or is null, just call set_visuals with no args
+		_ => {
+			return Ok(src
+				.call_id(byond_string!("set_visuals"), &[])
+				.wrap_err("Calling set_visuals with no args")?);
+		}
+	}
 }
 
 const fn adjacent_tile_id(id: u8, i: TurfID, max_x: i32, max_y: i32) -> TurfID {

--- a/src/turfs.rs
+++ b/src/turfs.rs
@@ -568,13 +568,13 @@ fn update_visuals(src: ByondValue) -> Result<ByondValue> {
 					byond_string!("set_visuals"),
 					&[overlay_types.as_slice().try_into()?],
 				)
-				.wrap_err("Calling set_visuals")?)
+				.wrap_err("Calling set_visuals"))
 		}
 		// If air is not defined or is null, just call set_visuals with no args
 		_ => {
 			return Ok(src
 				.call_id(byond_string!("set_visuals"), &[])
-				.wrap_err("Calling set_visuals with no args")?);
+				.wrap_err("Calling set_visuals with no args"));
 		}
 	}
 }

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -408,15 +408,14 @@ fn post_process() {
 				if should_react {
 					drop(sender.try_send(Box::new(move || {
 						let turf = ByondValue::new_ref(ValueType::Turf, id);
-						//turf is no longer valid for reactions
-						let Ok(air) = turf.read_var_id(byond_string!("air")) else {
-							return Ok(());
-						};
-						if air.is_null() {
-							return Ok(());
+						match turf.read_var_id(byond_string!("air")) {
+							Ok(air) if !air.is_null() => {
+								react_hook(air, turf).wrap_err("Reacting")?;
+								Ok(())
+							}
+							//turf is no longer valid for reactions
+							_ => Ok(()),
 						}
-						react_hook(air, turf).wrap_err("Reacting")?;
-						Ok(())
 					})));
 				}
 
@@ -424,14 +423,9 @@ fn post_process() {
 					drop(sender.try_send(Box::new(move || {
 						let turf = ByondValue::new_ref(ValueType::Turf, id);
 
-						// Not valid for visuals updating if it doesn't have air defined now
-						let Ok(air) = turf.read_var_id(byond_string!("air")) else {
-							return Ok(());
-						};
-						if air.is_null() {
-							return Ok(());
-						}
-						update_visuals(turf, air).wrap_err("Updating Visuals")?;
+						//Turf is checked for validity in update_visuals
+
+						update_visuals(turf).wrap_err("Updating Visuals")?;
 						Ok(())
 					})));
 				}

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -412,6 +412,9 @@ fn post_process() {
 						let Ok(air) = turf.read_var_id(byond_string!("air")) else {
 							return Ok(());
 						};
+						if air.is_null() {
+							return Ok(());
+						}
 						react_hook(air, turf).wrap_err("Reacting")?;
 						Ok(())
 					})));
@@ -422,14 +425,13 @@ fn post_process() {
 						let turf = ByondValue::new_ref(ValueType::Turf, id);
 
 						// Not valid for visuals updating if it doesn't have air defined now
-						if !turf
-							.read_var_id(byond_string!("air"))
-							.is_ok_and(|air| !air.is_null())
-						{
+						let Ok(air) = turf.read_var_id(byond_string!("air")) else {
+							return Ok(());
+						};
+						if air.is_null() {
 							return Ok(());
 						}
-
-						update_visuals(turf).wrap_err("Updating Visuals")?;
+						update_visuals(turf, air).wrap_err("Updating Visuals")?;
 						Ok(())
 					})));
 				}

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -423,8 +423,7 @@ fn post_process() {
 					drop(sender.try_send(Box::new(move || {
 						let turf = ByondValue::new_ref(ValueType::Turf, id);
 
-						//Turf is checked for validity in update_visuals
-
+						//turf is checked for validity in update_visuals
 						update_visuals(turf).wrap_err("Updating Visuals")?;
 						Ok(())
 					})));

--- a/src/turfs/processing.rs
+++ b/src/turfs/processing.rs
@@ -420,6 +420,15 @@ fn post_process() {
 				if should_update_vis {
 					drop(sender.try_send(Box::new(move || {
 						let turf = ByondValue::new_ref(ValueType::Turf, id);
+
+						// Not valid for visuals updating if it doesn't have air defined now
+						if !turf
+							.read_var_id(byond_string!("air"))
+							.is_ok_and(|air| !air.is_null())
+						{
+							return Ok(());
+						}
+
 						update_visuals(turf).wrap_err("Updating Visuals")?;
 						Ok(())
 					})));


### PR DESCRIPTION
On shiptest, we've had a bunch of randomly-occurring auxmos runtimes that I was unable to track down, until now. This should prevent turfs who, while their callback was queued, managed to either stop existing or at the very least lose their air variable. I'm not fully sure that this is the best solution, but it's one that I came up with that seems to work as far as I can tell.

Also clarifies some of the raised errors, as those functions will error on the object itself being null, rather than the variable on the object being null.